### PR TITLE
fix(war-room): rebuild Trinity layout — fixed viewport, absolute HUD overlay, timeline above bar

### DIFF
--- a/src/lib/components/coach/TacticalArena.svelte
+++ b/src/lib/components/coach/TacticalArena.svelte
@@ -13,58 +13,65 @@
 	onpointercancel={model.handlePointerCancel}
 />
 
-<div
-	class="tw-absolute tw-inset-4 tw-flex tw-min-h-0 tw-min-w-0 tw-items-center tw-justify-center tw-overflow-visible md:tw-inset-8"
->
+<!--
+  Pure SVG presentation layer — fills the fixed viewport.
+  overflow-visible on the inner wrappers so the radial hub and route anchors
+  can paint outside the board boundary without being clipped.
+-->
+<div class="tw-absolute tw-inset-0 tw-overflow-hidden">
 	<div
-		class="tw-relative tw-h-full tw-w-full tw-min-h-0 tw-min-w-0 tw-overflow-visible"
-		style="perspective: 2000px;"
+		class="tw-absolute tw-inset-4 tw-flex tw-min-h-0 tw-min-w-0 tw-items-center tw-justify-center tw-overflow-visible md:tw-inset-8"
 	>
-		<TacticalPitchBoard
-			bind:pitchSvgEl={model.pitchSvgEl}
-			isHolotableMode={model.isHolotableMode}
-			{warRoomTool}
-			showLabels={model.showLabels}
-			draggingPlayer={model.draggingPlayer}
-			activeDragTrail={model.activeDragTrail}
-			trailString={model.trailString}
-			dragTrailBloomColor={model.dragTrailBloomColor}
-			routesLive={model.routesLive}
-			routePathD={model.routePathD}
-			selectedRouteId={model.selectedRouteId}
-			simulatorTime={model.simulator.currentTime}
-			simulatorIsPlaying={model.simulator.isPlaying}
-			onRouteStrokePointerDown={model.input.onRouteStrokePointerDown}
-			onAnchorDown={model.input.onAnchorDown}
-			routingActive={model.routingActive}
-			routeDraft={model.routeDraft}
-			allPitchTokens={model.kineticPitchTokens}
-			hoveredDiscId={model.hoveredDiscId}
-			focusedPlayerId={model.focusedPlayerId}
-			ringColor={model.ringColor}
-			simChargePlayerIds={model.simChargePlayerIds}
-			startDrag={model.input.startDrag}
-			bumpRouteDelay={model.bumpRouteDelay}
-			allRouteMarkerColors={model.allRouteMarkerColors}
-			onPitchPointerDown={model.handlePointerDown}
-			onPitchPointerUpClearLongPress={model.onPitchPointerUpClearLongPress}
-			onPitchMouseLeave={model.input.onPitchMouseLeave}
-			onPitchContextMenu={model.onPitchContextMenu}
-			onTokenContextMenu={model.onTokenContextMenu}
-			handleSvgClick={model.handleSvgClick}
-			setHoveredRouteId={model.setHoveredRouteId}
-			setHoveredDiscId={model.setHoveredDiscId}
-			setFocusedPlayerId={model.setFocusedPlayerId}
-			showAnchorsFor={model.showAnchorsFor}
-			radialOpen={model.radial.radialOpen}
-			radialCx={model.radial.radialCx}
-			radialCy={model.radial.radialCy}
-			hubPop={model.radial.hubPop}
-			radialAllSlots={model.radial.radialAllSlots}
-			hubHoveredKey={model.radial.hubHoveredKey}
-			hubCenterLabel={model.radial.hubCenterLabel}
-			isLoadingCartridge={model.simulator.isLoadingCartridge}
-			cartridgeSweepEpoch={model.simulator.cartridgeSweepEpoch}
-		/>
+		<div
+			class="tw-relative tw-h-full tw-w-full tw-min-h-0 tw-min-w-0 tw-overflow-visible"
+			style="perspective: 2000px;"
+		>
+			<TacticalPitchBoard
+				bind:pitchSvgEl={model.pitchSvgEl}
+				isHolotableMode={model.isHolotableMode}
+				{warRoomTool}
+				showLabels={model.showLabels}
+				draggingPlayer={model.draggingPlayer}
+				activeDragTrail={model.activeDragTrail}
+				trailString={model.trailString}
+				dragTrailBloomColor={model.dragTrailBloomColor}
+				routesLive={model.routesLive}
+				routePathD={model.routePathD}
+				selectedRouteId={model.selectedRouteId}
+				simulatorTime={model.simulator.currentTime}
+				simulatorIsPlaying={model.simulator.isPlaying}
+				onRouteStrokePointerDown={model.input.onRouteStrokePointerDown}
+				onAnchorDown={model.input.onAnchorDown}
+				routingActive={model.routingActive}
+				routeDraft={model.routeDraft}
+				allPitchTokens={model.kineticPitchTokens}
+				hoveredDiscId={model.hoveredDiscId}
+				focusedPlayerId={model.focusedPlayerId}
+				ringColor={model.ringColor}
+				simChargePlayerIds={model.simChargePlayerIds}
+				startDrag={model.input.startDrag}
+				bumpRouteDelay={model.bumpRouteDelay}
+				allRouteMarkerColors={model.allRouteMarkerColors}
+				onPitchPointerDown={model.handlePointerDown}
+				onPitchPointerUpClearLongPress={model.onPitchPointerUpClearLongPress}
+				onPitchMouseLeave={model.input.onPitchMouseLeave}
+				onPitchContextMenu={model.onPitchContextMenu}
+				onTokenContextMenu={model.onTokenContextMenu}
+				handleSvgClick={model.handleSvgClick}
+				setHoveredRouteId={model.setHoveredRouteId}
+				setHoveredDiscId={model.setHoveredDiscId}
+				setFocusedPlayerId={model.setFocusedPlayerId}
+				showAnchorsFor={model.showAnchorsFor}
+				radialOpen={model.radial.radialOpen}
+				radialCx={model.radial.radialCx}
+				radialCy={model.radial.radialCy}
+				hubPop={model.radial.hubPop}
+				radialAllSlots={model.radial.radialAllSlots}
+				hubHoveredKey={model.radial.hubHoveredKey}
+				hubCenterLabel={model.radial.hubCenterLabel}
+				isLoadingCartridge={model.simulator.isLoadingCartridge}
+				cartridgeSweepEpoch={model.simulator.cartridgeSweepEpoch}
+			/>
+		</div>
 	</div>
 </div>

--- a/src/lib/components/coach/TacticalHUD.svelte
+++ b/src/lib/components/coach/TacticalHUD.svelte
@@ -91,33 +91,38 @@
 	}
 </script>
 
+<!--
+  HUD root: absolute overlay pinned to the bottom of the fixed viewport.
+  pointer-events-none so the board underneath stays fully interactive;
+  every interactive child re-enables pointer-events-auto individually.
+-->
 <div
-	class="tw-pointer-events-none tw-relative tw-z-50 tw-min-h-28 tw-shrink-0 tw-overflow-visible tw-border-t tw-border-white/10 tw-bg-[#020202]/85 tw-py-2 tw-pb-20 tw-backdrop-blur-3xl tw-transition-[box-shadow] tw-duration-300 tw-shadow-[inset_0_1px_1px_rgba(255,255,255,0.06),_0_-12px_40px_rgba(0,0,0,0.45)] {model.focusedPlayerId
+	class="tw-pointer-events-none tw-absolute tw-inset-x-0 tw-bottom-0 tw-z-50 tw-min-h-28 tw-overflow-visible tw-border-t tw-border-white/10 tw-bg-[#020202]/85 tw-py-2 tw-pb-20 tw-backdrop-blur-3xl tw-transition-[box-shadow] tw-duration-300 tw-shadow-[inset_0_1px_1px_rgba(255,255,255,0.06),_0_-12px_40px_rgba(0,0,0,0.45)] {model.focusedPlayerId
 		? 'tw-shadow-[inset_0_1px_0_rgba(255,0,60,0.35)]'
 		: ''}"
 >
-	<!-- Wrap GridHUD: HUD root is pointer-events-none, GridHUD reclaims interactivity -->
+	<!-- GridHUD: reclaims pointer-events-auto inside the pointer-events-none bar -->
 	<div class="tw-pointer-events-auto">
-	<GridHUD
-		bind:warRoomTool
-		pickTool={(t) => model.setActiveTool(t)}
-		bind:isHolotableMode={model.isHolotableMode}
-		simulator={model.simulator}
-		bind:showLabels={model.showLabels}
-		bind:activeRouteColor={model.activeRouteColor}
-		bind:routeDrawKind={model.routeDrawKind}
-		focusedPlayerId={model.focusedPlayerId}
-		allTokens={model.allPitchTokens}
-		recallBench={model.recallBench}
-		clearRoutesOnly={model.clearRoutesOnly}
-	/>
+		<GridHUD
+			bind:warRoomTool
+			pickTool={(t) => model.setActiveTool(t)}
+			bind:isHolotableMode={model.isHolotableMode}
+			simulator={model.simulator}
+			bind:showLabels={model.showLabels}
+			bind:activeRouteColor={model.activeRouteColor}
+			bind:routeDrawKind={model.routeDrawKind}
+			focusedPlayerId={model.focusedPlayerId}
+			allTokens={model.allPitchTokens}
+			recallBench={model.recallBench}
+			clearRoutesOnly={model.clearRoutesOnly}
+		/>
 	</div>
 
-	<!-- DEPLOY TO SQUAD ─────────────────────────────────────────────────────── -->
+	<!-- DEPLOY TO SQUAD ──────────────────────────────────────────────────────── -->
 	<div class="tw-pointer-events-auto tw-absolute tw-bottom-2 tw-right-4 tw-z-20">
 		<button
 			type="button"
-			class="tw-pointer-events-auto tw-flex tw-items-center tw-gap-2 tw-rounded-full tw-border tw-border-[#00f0ff]/40 tw-bg-[#020202]/80 tw-px-5 tw-py-2 tw-font-mono tw-text-xs tw-font-bold tw-uppercase tw-tracking-widest tw-text-[#00f0ff] tw-backdrop-blur-xl tw-transition-all hover:tw-border-[#00f0ff]/80 hover:tw-bg-[#00f0ff]/10 hover:tw-shadow-[0_0_20px_rgba(0,240,255,0.35)] active:tw-scale-95 disabled:tw-cursor-not-allowed disabled:tw-opacity-30"
+			class="tw-flex tw-items-center tw-gap-2 tw-rounded-full tw-border tw-border-[#00f0ff]/40 tw-bg-[#020202]/80 tw-px-5 tw-py-2 tw-font-mono tw-text-xs tw-font-bold tw-uppercase tw-tracking-widest tw-text-[#00f0ff] tw-backdrop-blur-xl tw-transition-all hover:tw-border-[#00f0ff]/80 hover:tw-bg-[#00f0ff]/10 hover:tw-shadow-[0_0_20px_rgba(0,240,255,0.35)] active:tw-scale-95 disabled:tw-cursor-not-allowed disabled:tw-opacity-30"
 			onclick={handleDeploy}
 			disabled={deployPhase !== 'idle' || model.routesLive.length === 0}
 		>
@@ -128,14 +133,18 @@
 		</button>
 	</div>
 
-	<!-- Playback reactor: physical scrub + clock (no native range) ─────────── -->
+	<!--
+	  Playback reactor: floats ABOVE the HUD bar (bottom-full = bottom edge at bar top edge).
+	  pointer-events-none on the positioner, auto on each interactive control.
+	-->
 	<div
-		class="tw-pointer-events-none tw-absolute tw-left-1/2 tw-top-full tw-z-[60] tw-flex tw--translate-x-1/2 tw-justify-center tw-pt-2"
+		class="tw-pointer-events-none tw-absolute tw-bottom-full tw-left-1/2 tw-z-[60] tw-flex tw--translate-x-1/2 tw-justify-center tw-pb-3"
 		aria-hidden="false"
 	>
 		<div class="tw-pointer-events-auto tw-flex tw-flex-col tw-items-center tw-gap-2">
+			<!-- Monospace scrub clock -->
 			<div
-				class="tw-pointer-events-auto tw-rounded-full tw-border tw-border-white/10 tw-bg-[#020202]/90 tw-px-6 tw-py-2 tw-backdrop-blur-xl tw-shadow-[inset_0_1px_1px_rgba(255,255,255,0.1)]"
+				class="tw-rounded-full tw-border tw-border-white/10 tw-bg-[#020202]/90 tw-px-6 tw-py-2 tw-backdrop-blur-xl tw-shadow-[inset_0_1px_1px_rgba(255,255,255,0.1)]"
 			>
 				<span
 					class="tw-font-mono tw-text-lg tw-font-bold tw-tracking-widest tw-tabular-nums tw-text-[#00f0ff]"
@@ -144,8 +153,9 @@
 				</span>
 			</div>
 
+			<!-- Physical scrub rail (no native range) -->
 			<div
-				class="tw-pointer-events-auto tw-relative tw-h-2 tw-w-[min(24rem,92vw)] tw-cursor-pointer tw-overflow-hidden tw-rounded-full tw-bg-white/10 tw-shadow-[inset_0_1px_2px_rgba(0,0,0,0.45)]"
+				class="tw-relative tw-h-2 tw-w-[min(24rem,92vw)] tw-cursor-pointer tw-overflow-hidden tw-rounded-full tw-bg-white/10 tw-shadow-[inset_0_1px_2px_rgba(0,0,0,0.45)]"
 				role="slider"
 				tabindex="0"
 				aria-valuemin="0"
@@ -163,9 +173,10 @@
 				></div>
 			</div>
 
+			<!-- Play / Pause -->
 			<button
 				type="button"
-				class="tw-pointer-events-auto tw-mt-1 tw-flex tw-h-12 tw-w-12 tw-shrink-0 tw-items-center tw-justify-center tw-rounded-full tw-border tw-border-[#00f0ff]/50 tw-bg-[#020202]/80 tw-text-[#00f0ff] tw-backdrop-blur-xl tw-transition-transform hover:tw-scale-110 hover:tw-bg-[#00f0ff]/15 hover:tw-shadow-[0_0_20px_rgba(0,240,255,0.35)]"
+				class="tw-mt-1 tw-flex tw-h-12 tw-w-12 tw-shrink-0 tw-items-center tw-justify-center tw-rounded-full tw-border tw-border-[#00f0ff]/50 tw-bg-[#020202]/80 tw-text-[#00f0ff] tw-backdrop-blur-xl tw-transition-transform hover:tw-scale-110 hover:tw-bg-[#00f0ff]/15 hover:tw-shadow-[0_0_20px_rgba(0,240,255,0.35)]"
 				aria-pressed={model.simulator.isPlaying}
 				aria-label={model.simulator.isPlaying ? 'Pause simulation' : 'Play simulation'}
 				onclick={() => model.toggleTimelinePlayback()}

--- a/src/routes/(app)/coach/tactical/+page.svelte
+++ b/src/routes/(app)/coach/tactical/+page.svelte
@@ -6,6 +6,8 @@
 	import { createTacticalWarRoom } from '$lib/components/coach/TacticalEngine.svelte.ts';
 	import TacticalArena from '$lib/components/coach/TacticalArena.svelte';
 	import TacticalHUD from '$lib/components/coach/TacticalHUD.svelte';
+	import { scale } from 'svelte/transition';
+	import { quintOut } from 'svelte/easing';
 
 	/** @typedef {import('$lib/states/war-room/types').TacticalToken} TacticalToken */
 
@@ -85,7 +87,19 @@
 	});
 </script>
 
-<div class="tw-relative tw-w-full tw-h-screen tw-overflow-hidden">
-	<TacticalArena model={engine} {warRoomTool} />
-	<TacticalHUD model={engine} bind:warRoomTool />
+<!-- Escape key handled here so it fires regardless of which child has focus -->
+<svelte:window onkeydown={engine.handleKeyDown} />
+
+<!--
+  tw-fixed tw-inset-0: breaks out of .ec-canvas scroll container, fills 100vw × 100dvh.
+  The scale transition makes the arena "pop out" like a hardware panel extruding from the surface.
+-->
+<div class="tw-fixed tw-inset-0 tw-overflow-hidden tw-bg-[#020202]" style="z-index: 40;">
+	<div
+		class="tw-absolute tw-inset-0"
+		in:scale={{ duration: 400, start: 0.97, easing: quintOut }}
+	>
+		<TacticalArena model={engine} {warRoomTool} />
+		<TacticalHUD model={engine} bind:warRoomTool />
+	</div>
 </div>


### PR DESCRIPTION
## Summary

- **`+page.svelte`** — `tw-fixed tw-inset-0` escapes `.ec-canvas` scroll container for true `100vw × 100dvh`; scale transition (quintOut, 400ms) on load; `svelte:window onkeydown` for Escape.
- **`TacticalArena.svelte`** — Added `tw-absolute tw-inset-0` root wrapper so the SVG layer fills its positioning context.
- **`TacticalHUD.svelte`** — Root changed from `tw-relative tw-shrink-0` (in-flow, collapses Arena) to `tw-absolute tw-inset-x-0 tw-bottom-0` overlay. Timeline changed from `tw-top-full` (off-screen below bar) to `tw-bottom-full` (floats above bar).

## Root causes fixed

| Bug | Cause | Fix |
|---|---|---|
| Collapsed layout | HUD in normal flow took height from Arena | HUD is now absolute overlay at bottom |
| Broken buttons | HUD rendered at wrong position, hit areas misaligned | Correct absolute positioning |
| Timeline off-screen | `tw-top-full` placed scrubber below bottom bar | `tw-bottom-full` floats it above the bar |
| Not fullscreen | `tw-h-screen` inside padded scroll container | `tw-fixed tw-inset-0` breaks out entirely |

`TacticalEngine.svelte.ts` unchanged — CTM try/catch fallback and context-menu `preventDefault` were already correct.

https://claude.ai/code/session_015ZD4gPoRbuydbHrBVQCCTD

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly layout/positioning changes, but they affect global viewport sizing and pointer-event layering, so regressions could break board interaction or HUD controls across devices.
> 
> **Overview**
> Fixes the tactical coach view layout by moving the root container to a fixed full-viewport overlay (`tw-fixed tw-inset-0`) and adding an entry `scale` transition; Escape handling is also lifted to a window-level keydown listener.
> 
> Rebuilds the arena/HUD stacking so the SVG board always fills its container (`TacticalArena` gets an absolute `inset-0` wrapper) while `TacticalHUD` becomes an absolute bottom overlay with carefully scoped `pointer-events` and repositions the playback scrubber to float *above* the HUD bar (`bottom-full` instead of `top-full`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66d6e9cf850d49b2d37462064cff0f13358f3e26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->