### PR TITLE
Add AGENTS.md with Cursor Cloud development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,49 +4,74 @@
 
 ### Overview
 
-This is a Firebase-powered PWA called **Sports Skill Tracker (SSTRACKER)**. It consists of:
-- **Frontend**: Vanilla JavaScript (ES modules) served as static files — no build step
-- **Backend**: Firebase Cloud Functions (Node.js 24) in `/functions/`
-- **Database/Auth**: Firebase (Firestore + Auth), connects to project `sports-skill-tracker-dev`
+This is a Firebase-powered PWA called **Sports Skill Tracker (SSTRACKER)**. The `dev` branch is the active development branch.
+
+**Dev branch stack (v5.0.0):**
+- **Frontend**: SvelteKit + Vite + Tailwind CSS
+- **Backend**: Firebase Cloud Functions (Node.js 22) in `/functions/`
+- **Database/Auth**: Firebase (Firestore + Auth), project `sports-skill-tracker-dev`
+- **Tests**: Vitest (unit/integration) + Playwright (e2e)
 
 ### Running the development server
 
 ```bash
-firebase emulators:start --only functions,hosting
+npm run dev
 ```
 
-This starts:
-- Hosting emulator on `http://127.0.0.1:5000` (serves the frontend)
-- Functions emulator on `http://127.0.0.1:5001`
-- Emulator UI on `http://127.0.0.1:4000`
-
-The frontend connects directly to the real Firebase dev project backend (not emulators) for Auth and Firestore. The hosting emulator just serves the static files locally.
+Starts the Vite dev server on `http://localhost:5173`.
 
 ### Lint
 
 ```bash
-cd functions && npm run lint
+npm run lint:functions
 ```
 
-Runs ESLint on Cloud Functions code only. There is no lint for the frontend (vanilla JS with no tooling).
+Note: On the `dev` branch, the functions `package.json` does not currently have a `lint` script, so `lint:functions` will fail. Lint checks are only available on the `main` branch functions.
 
 ### Tests
 
-There are no automated tests in this repository.
+**Unit/integration tests (Vitest):**
+```bash
+npm run test          # single run
+npm run test:watch    # watch mode
+```
 
-### Node.js version
+**E2E tests (Playwright):**
+```bash
+npm run test:e2e      # headless
+npm run test:e2e:ui   # with UI
+```
 
-The project requires Node.js 24 (specified in `functions/package.json` engines). The PATH must prioritize the nvm-installed Node.js 24 binary over the system default:
+Playwright is configured to auto-start the Vite dev server on port 5173.
+
+**Firestore rules tests:**
+```bash
+npm run test:firestore-rules
+```
+
+### Build
 
 ```bash
-export PATH="/home/ubuntu/.nvm/versions/node/v24.16.0/bin:$PATH"
+npm run build
 ```
+
+Runs `vite build` with a prebuild check (`check-no-phosphor.mjs` and `check-file-budget.mjs`).
+
+### Dependency installation notes
+
+- Root `npm install` requires `--legacy-peer-deps` due to a peer conflict between `firebase@^12` and `@firebase/rules-unit-testing` (expects `firebase@^11`).
+- Playwright browsers: `npx playwright install --with-deps chromium`
+- SvelteKit type generation: run `npx svelte-kit sync` before `svelte-check`
 
 ### Firebase project configuration
 
-- Dev project: `sports-skill-tracker-dev` (used by default via `.firebaserc`)
+- Dev project: `sports-skill-tracker-dev`
 - Prod project: `soccer-skills-tracker`
-- The `firebase-config.js` master switch controls which backend the frontend connects to
+- `.firebaserc` default points to prod; the frontend config uses the dev project for local development
+
+### Authentication for testing
+
+The player workspace requires OTP on every login. To run e2e tests or take dashboard screenshots, you need test credentials (provided via secrets: `TEST_LOGIN_USERNAME`, `TEST_LOGIN_PASSWORD`, `TEST_LOGIN_OTP_SEED`).
 
 ### Java requirement
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,57 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+This is a Firebase-powered PWA called **Sports Skill Tracker (SSTRACKER)**. It consists of:
+- **Frontend**: Vanilla JavaScript (ES modules) served as static files — no build step
+- **Backend**: Firebase Cloud Functions (Node.js 24) in `/functions/`
+- **Database/Auth**: Firebase (Firestore + Auth), connects to project `sports-skill-tracker-dev`
+
+### Running the development server
+
+```bash
+firebase emulators:start --only functions,hosting
+```
+
+This starts:
+- Hosting emulator on `http://127.0.0.1:5000` (serves the frontend)
+- Functions emulator on `http://127.0.0.1:5001`
+- Emulator UI on `http://127.0.0.1:4000`
+
+The frontend connects directly to the real Firebase dev project backend (not emulators) for Auth and Firestore. The hosting emulator just serves the static files locally.
+
+### Lint
+
+```bash
+cd functions && npm run lint
+```
+
+Runs ESLint on Cloud Functions code only. There is no lint for the frontend (vanilla JS with no tooling).
+
+### Tests
+
+There are no automated tests in this repository.
+
+### Known issues
+
+- `app.js` imports `initSpatialScheduler` from `modules/coach.js`, but that function is not exported from `coach.js`. This causes a JavaScript module error preventing frontend JS from loading in the browser. The static HTML/CSS renders correctly regardless.
+
+### Node.js version
+
+The project requires Node.js 24 (specified in `functions/package.json` engines). The PATH must prioritize the nvm-installed Node.js 24 binary over the system default:
+
+```bash
+export PATH="/home/ubuntu/.nvm/versions/node/v24.16.0/bin:$PATH"
+```
+
+### Firebase project configuration
+
+- Dev project: `sports-skill-tracker-dev` (used by default via `.firebaserc`)
+- Prod project: `soccer-skills-tracker`
+- The `firebase-config.js` master switch controls which backend the frontend connects to
+
+### Java requirement
+
+Firebase emulators require Java (OpenJDK 21 is pre-installed in the Cloud Agent environment).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,10 +34,6 @@ Runs ESLint on Cloud Functions code only. There is no lint for the frontend (van
 
 There are no automated tests in this repository.
 
-### Known issues
-
-- `app.js` imports `initSpatialScheduler` from `modules/coach.js`, but that function is not exported from `coach.js`. This causes a JavaScript module error preventing frontend JS from loading in the browser. The static HTML/CSS renders correctly regardless.
-
 ### Node.js version
 
 The project requires Node.js 24 (specified in `functions/package.json` engines). The PATH must prioritize the nvm-installed Node.js 24 binary over the system default:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud-specific development instructions for future agents working on this codebase, targeting the `dev` branch (SvelteKit + Vite + Tailwind + Vitest + Playwright).

## What's included

- Dev branch stack documentation (SvelteKit v5, Vite, Tailwind, Vitest, Playwright)
- Test commands (unit, e2e, firestore rules)
- `--legacy-peer-deps` requirement note for npm install
- OTP authentication requirement for e2e dashboard testing
- Firebase project configuration details

## Update Script

```
[ -f package.json ] && npm install --legacy-peer-deps
[ -f functions/package.json ] && (cd functions && npm install)
[ -f playwright.config.ts ] && npx playwright install --with-deps chromium
```

## Development Environment Verification

| Check | Status |
|-------|--------|
| Root npm install (--legacy-peer-deps) | ✅ |
| Functions npm install | ✅ |
| Playwright chromium installed | ✅ |
| Vite dev server starts (port 5173) | ✅ |
| Vitest runs (1701 pass / 87 pre-existing failures) | ✅ |
| Firebase Hosting emulator (main branch) | ✅ |

[App login screen on main branch](https://cursor.com/agents/bc-be02bf9e-31d7-4aa3-bf8e-4d9ae44420a5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapp_login_screen.webp)
[Firebase Emulator UI](https://cursor.com/agents/bc-be02bf9e-31d7-4aa3-bf8e-4d9ae44420a5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffirebase_emulator_ui.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be02bf9e-31d7-4aa3-bf8e-4d9ae44420a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be02bf9e-31d7-4aa3-bf8e-4d9ae44420a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

