### PR TITLE
feat(vpc): LAUNCH-VPC-UX — household minors skip email consent

### DIFF
--- a/src/lib/components/coppa/ConsentOverlay.svelte
+++ b/src/lib/components/coppa/ConsentOverlay.svelte
@@ -4,7 +4,7 @@
 	 * ─────────────────────
 	 * COPPA 2026 / Privacy Shield — Parental Consent Gate
 	 *
-	 * Rendered by the (app)/+layout.svelte when authStore.requiresConsent
+	 * Rendered by the (app)/+layout.svelte when authStore.requiresEmailConsent
 	 * is true (player is a minor whose coppaStatus !== 'granted').
 	 *
 	 * This component COVERS the entire PlayerShell with a Zero-Trust overlay.
@@ -77,6 +77,8 @@
 		errorMsg = '';
 
 		try {
+			// sendParentalConsentEmail returns { success: true } even when Trigger Email
+			// is not configured (mail write fails server-side). No mailQueued flag today.
 			await sendConsentEmailFn({ parentEmail: parentEmail.trim().toLowerCase() });
 			sentToEmail = parentEmail.trim().toLowerCase();
 			phase = 'sent';
@@ -134,6 +136,14 @@
 				Your account has been identified as belonging to a player under 13.
 				A parent or guardian must grant consent before you can access
 				<span class="co-accent">VANGUARD</span>.
+			</p>
+		</div>
+
+		<!-- ── Household path notice (legacy self-signup only) ─────────────── -->
+		<div class="co-household-banner" role="note">
+			<p class="co-household-banner__text">
+				If your parent created your account from their household, they should complete
+				consent at <strong>Parent dashboard → VPC</strong> — not via this email form.
 			</p>
 		</div>
 
@@ -359,6 +369,26 @@
 	.co-accent {
 		color: #14b8a6;
 		font-weight: 700;
+	}
+
+	/* ─── Household banner ──────────────────────────────────────────────────── */
+	.co-household-banner {
+		background: rgba(245, 158, 11, 0.08);
+		border: 1px solid rgba(245, 158, 11, 0.25);
+		border-radius: 8px;
+		padding: 0.75rem 1rem;
+	}
+
+	.co-household-banner__text {
+		margin: 0;
+		font-size: 0.72rem;
+		line-height: 1.6;
+		color: rgba(255, 255, 255, 0.65);
+		text-align: center;
+	}
+
+	.co-household-banner__text strong {
+		color: #fbbf24;
 	}
 
 	/* ─── Legal strip ───────────────────────────────────────────────────────── */

--- a/src/lib/stores/auth/__tests__/roleDerivations.test.ts
+++ b/src/lib/stores/auth/__tests__/roleDerivations.test.ts
@@ -4,6 +4,8 @@ import {
 	deriveIsConsented,
 	deriveNeedsOnboarding,
 	deriveRequiresConsent,
+	deriveRequiresEmailConsent,
+	deriveUsesHouseholdVpcPath,
 	deriveRoleFlags,
 	canAccess,
 	type AccessGate,
@@ -53,6 +55,52 @@ describe('auth/roleDerivations', () => {
 				userProfile: { isMinor: true, coppaStatus: 'granted' },
 			}),
 		).toBe(false);
+	});
+
+	describe('deriveRequiresEmailConsent (LAUNCH-VPC-UX)', () => {
+		const base = {
+			isAuthenticated: true,
+			isLoading: false,
+			role: 'player' as const,
+		};
+
+		it('parentProvisioned minor skips email consent but remains unconsented until VPC verified', () => {
+			const profile = {
+				isMinor: true,
+				coppaStatus: 'pending',
+				parentProvisioned: true,
+				householdId: 'hh-1',
+				vpcStatus: 'pending_parent',
+			};
+			expect(deriveRequiresEmailConsent({ ...base, userProfile: profile })).toBe(false);
+			expect(deriveRequiresConsent({ ...base, userProfile: profile })).toBe(true);
+			expect(deriveIsConsented({ ...base, userProfile: profile })).toBe(false);
+		});
+
+		it('householdId-only minor skips email consent', () => {
+			expect(
+				deriveRequiresEmailConsent({
+					...base,
+					userProfile: { isMinor: true, coppaStatus: 'pending', householdId: 'hh-2' },
+				}),
+			).toBe(false);
+		});
+
+		it('non-provisioned self-signup minor still requires email consent', () => {
+			expect(
+				deriveRequiresEmailConsent({
+					...base,
+					userProfile: { isMinor: true, coppaStatus: 'pending' },
+				}),
+			).toBe(true);
+		});
+
+		it('deriveUsesHouseholdVpcPath detects parentProvisioned or householdId', () => {
+			expect(deriveUsesHouseholdVpcPath({ parentProvisioned: true })).toBe(true);
+			expect(deriveUsesHouseholdVpcPath({ householdId: 'hh-3' })).toBe(true);
+			expect(deriveUsesHouseholdVpcPath({ householdId: '  ' })).toBe(false);
+			expect(deriveUsesHouseholdVpcPath(null)).toBe(false);
+		});
 	});
 
 	describe('deriveIsConsented (Sprint 2.1)', () => {

--- a/src/lib/stores/auth/authGates.svelte.js
+++ b/src/lib/stores/auth/authGates.svelte.js
@@ -3,6 +3,7 @@ import {
 	deriveIsConsented,
 	deriveNeedsOnboarding,
 	deriveRequiresConsent,
+	deriveRequiresEmailConsent,
 } from '$lib/stores/auth/roleDerivations.js';
 
 /** Derived onboarding / consent / clearance gates from user + session + tenant. */
@@ -18,6 +19,15 @@ export function createAuthGates(userState, sessionState, tenantState) {
 
 	const requiresConsent = $derived(
 		deriveRequiresConsent({
+			isAuthenticated: sessionState.isAuthenticated,
+			isLoading: sessionState.isLoading,
+			role: sessionState.role,
+			userProfile: userState.userProfile,
+		}),
+	);
+
+	const requiresEmailConsent = $derived(
+		deriveRequiresEmailConsent({
 			isAuthenticated: sessionState.isAuthenticated,
 			isLoading: sessionState.isLoading,
 			role: sessionState.role,
@@ -42,6 +52,9 @@ export function createAuthGates(userState, sessionState, tenantState) {
 		},
 		get requiresConsent() {
 			return requiresConsent;
+		},
+		get requiresEmailConsent() {
+			return requiresEmailConsent;
 		},
 		get isConsented() {
 			return isConsented;

--- a/src/lib/stores/auth/facade.svelte.js
+++ b/src/lib/stores/auth/facade.svelte.js
@@ -137,6 +137,9 @@ export function createAuthFacade() {
 		get requiresConsent() {
 			return gates.requiresConsent;
 		},
+		get requiresEmailConsent() {
+			return gates.requiresEmailConsent;
+		},
 		get isConsented() {
 			return gates.isConsented;
 		},

--- a/src/lib/stores/auth/roleDerivations.ts
+++ b/src/lib/stores/auth/roleDerivations.ts
@@ -95,6 +95,30 @@ export function deriveRequiresConsent(input: {
 	);
 }
 
+/** Parent-provisioned or household-linked minors use in-app VPC — not email consent. */
+export function deriveUsesHouseholdVpcPath(
+	userProfile: Record<string, unknown> | null,
+): boolean {
+	if (!userProfile) return false;
+	if (userProfile.parentProvisioned === true) return true;
+	const householdId = userProfile.householdId;
+	return typeof householdId === 'string' && householdId.trim() !== '';
+}
+
+/**
+ * LAUNCH-VPC-UX — email ConsentOverlay only for self-signup minors without a household.
+ * Household minors block on /vpc-pending until parentGrantVpcConsent completes.
+ */
+export function deriveRequiresEmailConsent(input: {
+	isAuthenticated: boolean;
+	isLoading: boolean;
+	role: string;
+	userProfile: Record<string, unknown> | null;
+}): boolean {
+	if (!deriveRequiresConsent(input)) return false;
+	return !deriveUsesHouseholdVpcPath(input.userProfile);
+}
+
 /**
  * Sprint 2.1 — unified COPPA + VPC consent gate for minor players.
  * Non-players and non-minors always pass. Minors require granted COPPA
@@ -137,4 +161,4 @@ export function deriveIsCleared(
 		return false;
 	}
 }
-
+

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -490,7 +490,7 @@ import Icon from '$lib/components/ui/Icon.svelte';
 			The overlay renders INSIDE the player block so VanguardVFX/scanlines are
 			still active beneath it, maintaining the Stark aesthetic.
 		-->
-		{#if authStore.requiresConsent}
+		{#if authStore.requiresEmailConsent}
 			<ConsentOverlay />
 		{/if}
 		<LoadoutUnlockCeremony

--- a/src/routes/(app)/vpc-pending/+page.svelte
+++ b/src/routes/(app)/vpc-pending/+page.svelte
@@ -2,20 +2,25 @@
 	import { browser } from '$app/environment';
 	import { goto } from '$app/navigation';
 	import { untrack } from 'svelte';
-	import { auth } from '$lib/firebase.js';
 	import { authStore } from '$lib/stores/auth.svelte.js';
 	import { applyLoginWaterfall } from '$lib/auth/loginRouting.js';
+	import { deriveUsesHouseholdVpcPath } from '$lib/stores/auth/roleDerivations.js';
 	import Icon from '$lib/components/ui/Icon.svelte';
-	import type { IconName } from '$lib/icons/registry.js';
 
 	const userEmail = $derived(authStore.user?.email || '');
 	const vpcStatus = $derived(authStore.userProfile?.vpcStatus || '');
+	const isHouseholdPath = $derived(
+		deriveUsesHouseholdVpcPath(authStore.userProfile as Record<string, unknown> | null),
+	);
 	const statusLabel = $derived.by(() => {
 		switch (vpcStatus) {
-			case 'pending': return 'Pending — Awaiting parent';
-			case 'pending_parent': return 'Pending — Awaiting parent';
-			case 'parent_consented': return 'Parent consented — Awaiting director approval';
-			default: return vpcStatus || 'Pending';
+			case 'pending':
+			case 'pending_parent':
+				return 'Pending — awaiting parent';
+			case 'parent_consented':
+				return 'Parent consented — finishing setup';
+			default:
+				return vpcStatus || 'Pending';
 		}
 	});
 
@@ -48,8 +53,7 @@
 
 	function copyParentLink() {
 		if (!browser) return;
-		const base = window.location.origin;
-		const link = `${base}/parent/vpc`;
+		const link = `${window.location.origin}/parent/vpc`;
 		navigator.clipboard.writeText(link).then(() => {
 			copyDone = true;
 			setTimeout(() => (copyDone = false), 2500);
@@ -65,9 +69,8 @@
 
 		<h1 class="vpc-pending__title">Parental consent required</h1>
 		<p class="vpc-pending__subtitle">
-			Your account is in a privacy-protected holding state while parental consent is verified.
-			You will gain full access once a parent completes the consent ceremony and your club director
-			approves the request.
+			Your account is in a privacy-protected holding state. A parent or guardian must
+			complete the in-app consent ceremony before you can access training and other features.
 		</p>
 
 		<div class="vpc-pending__status-row">
@@ -84,26 +87,38 @@
 
 		<div class="vpc-pending__steps">
 			<h2 class="vpc-pending__steps-title">Next steps for your parent or guardian</h2>
-			<ol class="vpc-pending__step-list">
-				<li>
-					<strong>Create a Parent account</strong> using the same platform at
-					<a href="/login" target="_blank" rel="noopener noreferrer">{browser ? window.location.origin : ''}/login</a>.
-					Select <em>Parent / guardian</em> during setup.
-				</li>
-				<li>
-					<strong>Link to your athlete</strong> — your club director will link your household
-					after the parent account is set up.
-				</li>
-				<li>
-					<strong>Complete the consent ceremony</strong> at
-					<em>Parent dashboard → Consent</em>. They must review the data-use disclosure and
-					sign the digital attestation.
-				</li>
-				<li>
-					<strong>Await director approval</strong> — your club director will receive an
-					in-platform alert and approve the final VPC request.
-				</li>
-			</ol>
+			{#if isHouseholdPath}
+				<ol class="vpc-pending__step-list">
+					<li>
+						<strong>Your parent already has an account</strong> on this platform.
+					</li>
+					<li>
+						Ask them to sign in and open
+						<strong>Parent dashboard → Consent (VPC)</strong>.
+					</li>
+					<li>
+						They will review the data-use disclosure and complete the in-app consent
+						ceremony. Your account unlocks automatically when they finish.
+					</li>
+				</ol>
+			{:else}
+				<ol class="vpc-pending__step-list">
+					<li>
+						<strong>Create a Parent account</strong> using the same platform at
+						<a href="/login" target="_blank" rel="noopener noreferrer">{browser ? window.location.origin : ''}/login</a>.
+						Select <em>Parent / guardian</em> during setup.
+					</li>
+					<li>
+						<strong>Link to your athlete</strong> — your club director will link your household
+						after the parent account is set up.
+					</li>
+					<li>
+						<strong>Complete the consent ceremony</strong> at
+						<em>Parent dashboard → Consent (VPC)</em>. They must review the data-use disclosure
+						and sign the digital attestation in the app.
+					</li>
+				</ol>
+			{/if}
 		</div>
 
 		<div class="vpc-pending__actions">
@@ -127,7 +142,8 @@
 		</div>
 
 		<p class="vpc-pending__footer-note">
-			Questions? Contact your club director directly — they can expedite the approval process.
+			Questions? Ask your parent or guardian, or contact your club director for help linking
+			your household.
 		</p>
 	</div>
 </div>


### PR DESCRIPTION
## Summary

- Adds `deriveRequiresEmailConsent` / `deriveUsesHouseholdVpcPath` so parent-provisioned and household-linked minors skip the email `ConsentOverlay` and block on `/vpc-pending` until in-app VPC completes.
- Updates `/vpc-pending` copy: Parent dashboard → Consent (VPC); removes director approval and inbox steps.
- Legacy self-signup minors still get `ConsentOverlay` with a banner pointing household accounts to Parent dashboard → VPC.

## Manual QA (signed off on qa tenant)

| Scenario | Result |
|---|---|
| Parent-first: waiver → provision → `/parent/vpc` → child login | Pass — VPC verified, no ConsentOverlay |
| Child lands in Player OS after parent consent | Pass |
| Operative appears on coach roster | Pass |

## Test plan

- [x] `npm test -- src/lib/stores/auth/__tests__/roleDerivations.test.ts`
- [x] `npm run build`

## Agent handoff — what's next (LAUNCH-functional-os)

**VPC golden path:** Done for this slice.

### Cross-persona loop (highest priority)
1. **Coach → Player bounty handoff** — assign on `/coach/assignments` → player HQ mission rail → train → XP
2. **Parent co-op log** — `/parent/log-workout` → child progress
3. **Parent bounty terminal** — `/parent/dashboard`

### Player OS smoke
4. Train → log workout → XP/streak on HQ
5. Armory SYNC IDENTITY (default portrait OK)

### Epic 4 (ROADMAP: 4.4 → 4.3)
6. Parent Lounge reply UX on `/messages`
7. Notification bus (FCM)

**Out of scope next slice:** `sendParentalConsentEmail` backend, `parentGrantVpcConsent` backend, household page copy.