### PR TITLE
fix(coach): Coach→Player bounty handoff (us-east1 deploy + operative uid)

### DIFF
--- a/functions/src/domains/operativeOps.js
+++ b/functions/src/domains/operativeOps.js
@@ -1203,6 +1203,7 @@ exports.parentProvisionOperative = onCall({region: REGION}, async (request) => {
   );
   nameSet.add(childName);
   const userPayload = {
+    uid: childUid,
     role: 'player',
     clubId,
     householdId: hid,

--- a/src/lib/gamification/__tests__/personaFunctionalMvp.test.ts
+++ b/src/lib/gamification/__tests__/personaFunctionalMvp.test.ts
@@ -118,3 +118,48 @@ describe('Sprint LAUNCH-functional-os — launch-focus rule', () => {
 		expect(rule).toMatch(/Epic 4/);
 	});
 });
+
+describe('Sprint LAUNCH-functional-os — Coach→Player bounty handoff', () => {
+	const INTENT_ENGINE = join(ROOT, 'routes/(app)/coach/assignments/IntentEngine.svelte.ts');
+	const ACTIVE_BOUNTIES = join(ROOT, 'lib/components/hud/ActiveBounties.svelte');
+	const WORKOUT_PAGE = join(ROOT, 'routes/(app)/player/workout/+page.svelte');
+	const FIREBASE = join(ROOT, 'lib/firebase.js');
+	const OPERATIVE_OPS = join(ROOT, '..', 'functions/src/domains/operativeOps.js');
+
+	it('IntentEngine deploys intents via us-east1 functions bundle', () => {
+		expect(existsSync(INTENT_ENGINE)).toBe(true);
+		const src = readFileSync(INTENT_ENGINE, 'utf-8');
+		expect(src).toMatch(/from '\$lib\/firebase\.js'/);
+		expect(src).toMatch(/httpsCallable[\s\S]*functions[\s\S]*'secureDeployIntent'/);
+		expect(src).not.toMatch(/getFunctions\(\)/);
+	});
+
+	it('ActiveBounties subscribes to team_assignments and deduplicates missions', () => {
+		expect(existsSync(ACTIVE_BOUNTIES)).toBe(true);
+		const src = readFileSync(ACTIVE_BOUNTIES, 'utf-8');
+		expect(src).toMatch(/team_assignments/);
+		expect(src).toMatch(/bountyFromCoachIntent/);
+		expect(src).toMatch(/deduplicateById/);
+		expect(src).toMatch(/stashMissionHandoff/);
+	});
+
+	it('Train page logs sessions and records quest progress after coach handoff', () => {
+		expect(existsSync(WORKOUT_PAGE)).toBe(true);
+		const src = readFileSync(WORKOUT_PAGE, 'utf-8');
+		expect(src).toMatch(/logTrainingSession/);
+		expect(src).toMatch(/recordQuestProgressAfterLog/);
+		expect(src).toMatch(/from '\$lib\/firebase\.js'/);
+	});
+
+	it('firebase.js pins Cloud Functions to us-east1', () => {
+		expect(existsSync(FIREBASE)).toBe(true);
+		const src = readFileSync(FIREBASE, 'utf-8');
+		expect(src).toMatch(/getFunctions\(app,\s*'us-east1'\)/);
+	});
+
+	it('parentProvisionOperative persists Firebase uid on users doc for roster targeting', () => {
+		expect(existsSync(OPERATIVE_OPS)).toBe(true);
+		const src = readFileSync(OPERATIVE_OPS, 'utf-8');
+		expect(src).toMatch(/uid:\s*childUid/);
+	});
+});

--- a/src/lib/gamification/__tests__/playerRlFunctional.test.ts
+++ b/src/lib/gamification/__tests__/playerRlFunctional.test.ts
@@ -77,6 +77,8 @@ describe('Sprint RL-inference-on-train — shared policy cache + Train fetch', (
 		expect(src).toMatch(/ensureRlPolicyCached/);
 		expect(src).toMatch(/readRlPolicyCache/);
 		expect(src).not.toMatch(/cachePolicyHints/);
+		expect(src).toMatch(/httpsCallable\(functions,\s*'getAdaptiveWorkoutPolicy'/);
+		expect(src).not.toMatch(/getFunctions\(\)/);
 	});
 
 	it('Train page fetches getAdaptiveWorkoutPolicy when coach intent armed via cache helper', () => {

--- a/src/routes/(app)/coach/assignments/IntentEngine.svelte.ts
+++ b/src/routes/(app)/coach/assignments/IntentEngine.svelte.ts
@@ -23,8 +23,8 @@ import {
 	getDocs,
 	type Unsubscribe,
 } from 'firebase/firestore';
-import { getFunctions, httpsCallable } from 'firebase/functions';
-import { db } from '$lib/firebase.js';
+import { httpsCallable } from 'firebase/functions';
+import { db, functions } from '$lib/firebase.js';
 import { getRpgSportConfig } from '$lib/config/sports.js';
 import type {
 	IntentDoc,
@@ -232,7 +232,7 @@ export class IntentEngine {
 		this.deployError = '';
 		try {
 			const fn = httpsCallable<DeployIntentInput, DeployIntentResult>(
-				getFunctions(),
+				functions,
 				'secureDeployIntent',
 			);
 			await fn({
@@ -259,7 +259,7 @@ export class IntentEngine {
 		this.mutationError = '';
 		try {
 			const fn = httpsCallable<CancelIntentInput, CancelIntentResult>(
-				getFunctions(),
+				functions,
 				'secureCancelIntent',
 			);
 			await fn({ intentId, teamId: this._teamId, tenantId: this._tenantId });
@@ -272,7 +272,7 @@ export class IntentEngine {
 		this.mutationError = '';
 		try {
 			const fn = httpsCallable<ExtendIntentInput, ExtendIntentResult>(
-				getFunctions(),
+				functions,
 				'secureExtendIntent',
 			);
 			await fn({ intentId, teamId: this._teamId, tenantId: this._tenantId, additionalDays });
@@ -323,8 +323,12 @@ export class IntentEngine {
 			const rows: RosterEntry[] = snap.docs
 				.map((d) => {
 					const x = d.data();
+					const authUid =
+						typeof x.uid === 'string' && x.uid.trim() && !x.uid.includes('@') ?
+							x.uid.trim()
+						:	'';
 					return {
-						uid: (x.uid as string) || d.id,
+						uid: authUid,
 						email: d.id,
 						playerName: typeof x.playerName === 'string' && x.playerName.trim()
 							? x.playerName.trim()
@@ -332,6 +336,7 @@ export class IntentEngine {
 						xpByAttribute: (x.xpByAttribute as Record<string, number>) || {},
 					};
 				})
+				.filter((r) => r.uid.length > 0)
 				.sort((a, b) => a.playerName.localeCompare(b.playerName));
 			this.roster = rows;
 		} catch (e) {

--- a/src/routes/(app)/player/dashboard/AdaptiveHomework.svelte
+++ b/src/routes/(app)/player/dashboard/AdaptiveHomework.svelte
@@ -12,8 +12,8 @@
 	} from 'firebase/firestore';
 	import { goto } from '$app/navigation';
 	import { resolve } from '$app/paths';
-	import { getFunctions, httpsCallable } from 'firebase/functions';
-	import { db } from '$lib/firebase.js';
+	import { httpsCallable } from 'firebase/functions';
+	import { db, functions } from '$lib/firebase.js';
 	import { stashCoachIntentHandoffForAssignment, buildPolicyHintsFromResult } from '$lib/player/workout/coachMissionFlow.js';
 	import { ensureRlPolicyCached, readRlPolicyCache } from '$lib/player/workout/rlPolicyCache.js';
 	import { authStore } from '$lib/stores/auth.svelte.js';
@@ -160,8 +160,7 @@
 				const result = await ensureRlPolicyCached({
 					sportId,
 					fetchPolicy: async (sid) => {
-						const fns = getFunctions();
-						const getPolicy = httpsCallable(fns, 'getAdaptiveWorkoutPolicy');
+						const getPolicy = httpsCallable(functions, 'getAdaptiveWorkoutPolicy');
 						const res = await getPolicy({ sportId: sid });
 						return res.data;
 					},


### PR DESCRIPTION
## Summary

- **Root cause:** `IntentEngine` called `getFunctions()` (default `us-central1`) while all SSTracker callables deploy to **`us-east1`** — coach deploy silently failed or hit the wrong region.
- **Fix:** Route `secureDeployIntent` / cancel / extend through shared `functions` from `$lib/firebase.js`.
- **Operative uid:** `parentProvisionOperative` now writes `uid: childUid` on `users/{email}` so players-scoped intents and roster targeting use Firebase Auth uid (not email fallback).
- **AdaptiveHomework:** same region fix for `getAdaptiveWorkoutPolicy`.
- **Guards:** `personaFunctionalMvp.test.ts` Coach→Player handoff wiring block.

## Manual QA

1. Coach → `/coach/assignments` → deploy team-scoped intent (default).
2. Player HQ → mission rail shows **Coach Challenge**.
3. Accept → Train → log workout → XP/streak updates on HQ.

**Note:** Existing operatives provisioned before this PR may lack `users.uid`; use **team scope** deploy (default) or re-provision. New operatives get uid automatically.

## Test plan

- [x] `npm test -- src/lib/gamification/__tests__/personaFunctionalMvp.test.ts`
- [x] `npm run build`
- [ ] Deploy `functions-core` (operativeOps uid field) + hosting after merge

## Functions deploy

```bash
npm run deploy:core
```