### PR TITLE
fix: stop player bounty refresh loop and load Forge intents

### DIFF
--- a/src/lib/components/hud/ActiveBounties.svelte
+++ b/src/lib/components/hud/ActiveBounties.svelte
@@ -12,7 +12,8 @@
 		where,
 	} from 'firebase/firestore';
 	import { db } from '$lib/firebase.js';
-	import { createMissionSnapshotRetryHandler } from '$lib/player/dashboard/missionRailAuth.js';
+	import { MissionSnapshotRetryGate } from '$lib/player/dashboard/missionRailAuth.js';
+	import { fetchCoachIntentQuests, mapCoachIntentRows, coachIntentRemovalDelta, applyCoachIntentPurge, applyCoachIntentRefetch } from '$lib/player/dashboard/missionRailCoachIntents.js';
 	import { MissionRailClaimsSync } from '$lib/player/dashboard/missionRailClaims.svelte.js';
 	import { authStore } from '$lib/stores/auth.svelte.js';
 	import { dopamineExplosion } from '$lib/services/dopamine.svelte.js';
@@ -20,7 +21,6 @@
 	import { deduplicateById } from '$lib/utils/deduplicateMissions.js';
 	import {
 		buildDailyQuests,
-		bountyFromCoachIntent,
 		bountyFromHomeworkAssignment,
 		bountyFromParentBounty,
 		countCadenceSessionsInWindow,
@@ -30,7 +30,6 @@
 		markQuestClaimed,
 		markQuestCompleted,
 		maxVisibleQuests,
-		purgeCoachIntentIds,
 		formatQuestRewardLabel,
 		isPromotedQuest,
 		questCtaLabel,
@@ -88,7 +87,9 @@
 	let refreshNonce = $state(0);
 	let isRefreshing = $state(false);
 	let missionSyncBlocked = $state(false);
+	let hasQuestLogLoaded = $state(false);
 	const missionClaimsSync = new MissionRailClaimsSync();
+	const missionRetryGate = new MissionSnapshotRetryGate();
 	let lastCoachIntentIds = $state<string[]>([]);
 	/** Flat completion records for cadence progress — fetched once per uid, not real-time. */
 	let cadenceCompletions = $state<Array<{ attributeId: string; loggedAtMs: number }>>([]);
@@ -243,33 +244,29 @@
 	const teamId = $derived(
 		typeof authStore.userProfile?.teamId === 'string' ? authStore.userProfile.teamId.trim() : '',
 	);
+	const clubId = $derived(
+		typeof authStore.userProfile?.clubId === 'string' ? authStore.userProfile.clubId.trim() : '',
+	);
 
-	$effect(() => missionClaimsSync.watch(teamId));
+	$effect(() => missionClaimsSync.watch(teamId, clubId));
 
 	$effect(() => {
 		if (questsProp !== undefined) return;
 
-		if (!browser || authStore.isLoading || authStore.role !== 'player') {
+		if (!browser || authStore.isLoading || authStore.role !== 'player' || !playerUid) {
 			internalLoading = false;
 			internalQuests = [];
+			hasQuestLogLoaded = false;
+			missionRetryGate.reset();
 			return;
 		}
-
-		void refreshNonce;
-		void missionClaimsSync.claimsSyncNonce;
 
 		const uid = playerUid;
 		const email = playerEmail;
 		const tid = teamId;
 		const profile = authStore.userProfile;
 
-		if (!uid) {
-			internalLoading = false;
-			internalQuests = [];
-			return;
-		}
-
-		internalLoading = true;
+		if (!hasQuestLogLoaded) internalLoading = true;
 		questProgress = loadQuestProgress();
 
 		/** @type {QuestTask[]} */
@@ -292,29 +289,26 @@
 			);
 			internalQuests = sortQuestLog(merged);
 			internalLoading = false;
+			hasQuestLogLoaded = true;
 		};
 
 		const syncCoachIntentRemoval = (activeIds: Set<string>) => {
-			const removed = lastCoachIntentIds.filter((id) => !activeIds.has(id));
-			lastCoachIntentIds = [...activeIds];
+			const { removed, nextIds } = coachIntentRemovalDelta(lastCoachIntentIds, activeIds);
+			lastCoachIntentIds = nextIds;
 			if (removed.length === 0) return;
-			questProgress = purgeCoachIntentIds(questProgress, removed);
-			const handoff = readMissionHandoff();
-			if (handoff?.source === 'coach_intent' && removed.includes(handoff.missionId)) {
-				clearMissionHandoff();
-			}
+			questProgress = applyCoachIntentPurge(questProgress, removed);
 		};
 
 		const applyCoachIntents = (scopedRows: Array<{ id: string } & Record<string, unknown>>) => {
-			const activeIds = new Set(scopedRows.map((row) => row.id));
-			syncCoachIntentRemoval(activeIds);
 			const progress = loadQuestProgress();
-			intentDataById = Object.fromEntries(
-				scopedRows.map((row) => [row.id, row as Record<string, unknown>]),
+			const { quests, intentDataById: nextIntentData, activeIds } = mapCoachIntentRows(
+				scopedRows,
+				progress,
+				uid,
 			);
-			intents = scopedRows
-				.map((row) => bountyFromCoachIntent(row.id, row, progress, uid))
-				.filter((b): b is QuestTask => b != null);
+			syncCoachIntentRemoval(activeIds);
+			intentDataById = nextIntentData;
+			intents = quests;
 			merge();
 		};
 
@@ -327,19 +321,24 @@
 				where('status', '==', 'active'),
 				orderBy('priority', 'asc'),
 			);
-			const handleIntentSnapshotError = createMissionSnapshotRetryHandler(
-				() => {
-					isRefreshing = true;
-					void authStore.refreshClaims().finally(() => { refreshNonce += 1; });
-				},
-				() => {
-					missionSyncBlocked = true;
-					syncCoachIntentRemoval(new Set());
-					intents = [];
-					intentDataById = {};
-					merge();
-				},
-			);
+			const handleIntentSnapshotError = () => {
+				missionRetryGate.onError(
+					() => {
+						isRefreshing = true;
+						void authStore.refreshClaims().finally(() => {
+							refreshNonce += 1;
+						});
+					},
+					() => {
+						missionSyncBlocked = true;
+						isRefreshing = false;
+						syncCoachIntentRemoval(new Set());
+						intents = [];
+						intentDataById = {};
+						merge();
+					},
+				);
+			};
 			const mapIntentRows = (docs: { id: string; data: () => Record<string, unknown> }[]) =>
 				docs
 					.map((d) => ({ id: d.id, ...d.data() }))
@@ -349,26 +348,14 @@
 					intentQ,
 					(snap) => {
 						missionSyncBlocked = false;
+						missionRetryGate.onSuccess();
+						isRefreshing = false;
 						const uniqueDocs = [...new Map(snap.docs.map((d) => [d.id, d])).values()];
 						applyCoachIntents(mapIntentRows(uniqueDocs));
 					},
 					handleIntentSnapshotError,
 				),
 			);
-
-			if (refreshNonce > 0) {
-				void getDocs(intentQ)
-					.then((snap) => {
-						const uniqueDocs = [...new Map(snap.docs.map((d) => [d.id, d])).values()];
-						applyCoachIntents(mapIntentRows(uniqueDocs));
-					})
-					.catch(() => {
-						/* snapshot error handler covers persistent failures */
-					})
-					.finally(() => {
-						isRefreshing = false;
-					});
-			}
 		}
 
 		const hwQ = query(
@@ -427,6 +414,37 @@
 		return () => {
 			for (const u of unsubs) u();
 		};
+	});
+
+	$effect(() => {
+		if (questsProp !== undefined) return;
+		void refreshNonce;
+		void missionClaimsSync.claimsSyncNonce;
+		if (!browser || authStore.isLoading || authStore.role !== 'player') return;
+		const tid = teamId;
+		if (!tid || (refreshNonce === 0 && missionClaimsSync.claimsSyncNonce === 0)) return;
+		isRefreshing = true;
+		void fetchCoachIntentQuests(db, tid, playerUid, loadQuestProgress())
+			.then((snapshot) => {
+				missionSyncBlocked = false;
+				missionRetryGate.onSuccess();
+				const applied = applyCoachIntentRefetch({
+					snapshot,
+					lastCoachIntentIds,
+					internalQuests,
+					questProgress,
+				});
+				lastCoachIntentIds = applied.lastCoachIntentIds;
+				questProgress = applied.questProgress;
+				intentDataById = applied.intentDataById;
+				internalQuests = applied.internalQuests;
+				internalLoading = false;
+				hasQuestLogLoaded = true;
+			})
+			.catch(() => {})
+			.finally(() => {
+				isRefreshing = false;
+			});
 	});
 
 	function refreshQuestLog() {

--- a/src/lib/gamification/__tests__/personaFunctionalMvp.test.ts
+++ b/src/lib/gamification/__tests__/personaFunctionalMvp.test.ts
@@ -160,8 +160,13 @@ describe('Sprint LAUNCH-functional-os — Coach→Player bounty handoff', () => 
 	it('ActiveBounties subscribes to team_assignments and deduplicates missions', () => {
 		expect(existsSync(ACTIVE_BOUNTIES)).toBe(true);
 		const src = readFileSync(ACTIVE_BOUNTIES, 'utf-8');
+		const coachIntents = readFileSync(
+			join(ROOT, 'lib/player/dashboard/missionRailCoachIntents.ts'),
+			'utf-8',
+		);
 		expect(src).toMatch(/team_assignments/);
-		expect(src).toMatch(/bountyFromCoachIntent/);
+		expect(coachIntents).toMatch(/bountyFromCoachIntent/);
+		expect(src).toMatch(/fetchCoachIntentQuests|mapCoachIntentRows/);
 		expect(src).toMatch(/deduplicateById/);
 		expect(src).toMatch(/stashMissionHandoff/);
 	});
@@ -173,7 +178,7 @@ describe('Sprint LAUNCH-functional-os — Coach→Player bounty handoff', () => 
 		expect(sync).toMatch(/getIdTokenResult/);
 		expect(sync).toMatch(/refreshClaimsIfProfileTeamStale/);
 		expect(src).toMatch(/MissionRailClaimsSync/);
-		expect(src).toMatch(/createMissionSnapshotRetryHandler/);
+		expect(src).toMatch(/MissionSnapshotRetryGate/);
 		expect(src).toMatch(/missionClaimsSync\.claimsSyncNonce/);
 		expect(src).toMatch(/Mission sync blocked/);
 	});

--- a/src/lib/player/dashboard/__tests__/missionRailAuth.test.ts
+++ b/src/lib/player/dashboard/__tests__/missionRailAuth.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi } from 'vitest';
+import { MissionSnapshotRetryGate } from '../missionRailAuth.js';
+
+describe('MissionSnapshotRetryGate', () => {
+	it('retries once then blocks', () => {
+		const gate = new MissionSnapshotRetryGate();
+		const onRetry = vi.fn();
+		const onBlocked = vi.fn();
+
+		gate.onError(onRetry, onBlocked);
+		gate.onError(onRetry, onBlocked);
+
+		expect(onRetry).toHaveBeenCalledTimes(1);
+		expect(onBlocked).toHaveBeenCalledTimes(1);
+	});
+
+	it('resets after successful snapshot', () => {
+		const gate = new MissionSnapshotRetryGate();
+		const onRetry = vi.fn();
+		const onBlocked = vi.fn();
+
+		gate.onError(onRetry, onBlocked);
+		gate.onSuccess();
+		gate.onError(onRetry, onBlocked);
+
+		expect(onRetry).toHaveBeenCalledTimes(2);
+		expect(onBlocked).not.toHaveBeenCalled();
+	});
+});

--- a/src/lib/player/dashboard/missionRailAuth.ts
+++ b/src/lib/player/dashboard/missionRailAuth.ts
@@ -3,14 +3,34 @@ import { getIdTokenResult } from 'firebase/auth';
 import { auth } from '$lib/firebase.js';
 import { authStore } from '$lib/stores/auth.svelte.js';
 
-/** Refresh JWT when Firestore profile has teamId but token claims do not (QA-142). */
-export async function refreshClaimsIfProfileTeamStale(profileTeamId: string): Promise<boolean> {
-	if (!browser || !profileTeamId || !auth.currentUser) return false;
+function claimClubId(claims: Record<string, unknown>): string {
+	const club =
+		typeof claims.clubId === 'string' ? claims.clubId.trim()
+		: typeof claims.tenantId === 'string' ? claims.tenantId.trim()
+		: '';
+	return club;
+}
+
+/**
+ * Refresh JWT when Firestore profile has team/club scope but token claims do not (QA-142).
+ * team_assignments list rules require both tokenTeam() and tokenClub().
+ */
+export async function refreshClaimsIfProfileTeamStale(
+	profileTeamId: string,
+	profileClubId = '',
+): Promise<boolean> {
+	if (!browser || !auth.currentUser) return false;
+	const teamId = profileTeamId.trim();
+	const clubId = profileClubId.trim();
+	if (!teamId && !clubId) return false;
 	try {
 		const tr = await getIdTokenResult(auth.currentUser, false);
 		const claimTeamId =
 			typeof tr.claims.teamId === 'string' ? tr.claims.teamId.trim() : '';
-		if (profileTeamId && !claimTeamId) {
+		const claimClub = claimClubId(tr.claims as Record<string, unknown>);
+		const teamStale = Boolean(teamId && !claimTeamId);
+		const clubStale = Boolean(clubId && !claimClub);
+		if (teamStale || clubStale) {
 			await authStore.refreshClaims();
 			return true;
 		}
@@ -20,18 +40,33 @@ export async function refreshClaimsIfProfileTeamStale(profileTeamId: string): Pr
 	return false;
 }
 
-/** One refreshClaims retry before reporting mission sync blocked. */
-export function createMissionSnapshotRetryHandler(
-	onRetry: () => void,
-	onBlocked: () => void,
-): () => void {
-	let retried = false;
-	return () => {
-		if (!retried) {
-			retried = true;
+/** Persists retry state across Svelte effect re-runs (prevents infinite refresh loops). */
+export class MissionSnapshotRetryGate {
+	private retried = false;
+
+	onError(onRetry: () => void, onBlocked: () => void): void {
+		if (!this.retried) {
+			this.retried = true;
 			onRetry();
 			return;
 		}
 		onBlocked();
-	};
+	}
+
+	onSuccess(): void {
+		this.retried = false;
+	}
+
+	reset(): void {
+		this.retried = false;
+	}
+}
+
+/** @deprecated Prefer MissionSnapshotRetryGate — factory resets state on every call. */
+export function createMissionSnapshotRetryHandler(
+	onRetry: () => void,
+	onBlocked: () => void,
+): () => void {
+	const gate = new MissionSnapshotRetryGate();
+	return () => gate.onError(onRetry, onBlocked);
 }

--- a/src/lib/player/dashboard/missionRailClaims.svelte.ts
+++ b/src/lib/player/dashboard/missionRailClaims.svelte.ts
@@ -6,11 +6,11 @@ import { refreshClaimsIfProfileTeamStale } from '$lib/player/dashboard/missionRa
 export class MissionRailClaimsSync {
 	claimsSyncNonce = $state(0);
 
-	watch(profileTeamId: string) {
+	watch(profileTeamId: string, profileClubId = '') {
 		if (!browser || authStore.isLoading || authStore.role !== 'player') return;
-		if (!profileTeamId) return;
+		if (!profileTeamId.trim() && !profileClubId.trim()) return;
 		let cancelled = false;
-		void refreshClaimsIfProfileTeamStale(profileTeamId).then((refreshed) => {
+		void refreshClaimsIfProfileTeamStale(profileTeamId, profileClubId).then((refreshed) => {
 			if (refreshed && !cancelled) this.claimsSyncNonce += 1;
 		});
 		return () => {

--- a/src/lib/player/dashboard/missionRailCoachIntents.ts
+++ b/src/lib/player/dashboard/missionRailCoachIntents.ts
@@ -1,0 +1,115 @@
+import {
+	collection,
+	getDocs,
+	orderBy,
+	query,
+	where,
+	type Firestore,
+} from 'firebase/firestore';
+import {
+	bountyFromCoachIntent,
+	intentAssignmentVisibleToPlayer,
+	purgeCoachIntentIds,
+	sortQuestLog,
+	type QuestProgressStore,
+	type QuestTask,
+} from '$lib/player/dashboard/activeBounties.js';
+import {
+	clearMissionHandoff,
+	readMissionHandoff,
+} from '$lib/player/workout/coachMissionFlow.js';
+
+export type CoachIntentSnapshot = {
+	quests: QuestTask[];
+	intentDataById: Record<string, Record<string, unknown>>;
+	activeIds: Set<string>;
+};
+
+export function mapCoachIntentRows(
+	scopedRows: Array<{ id: string } & Record<string, unknown>>,
+	progress: QuestProgressStore,
+	playerUid: string,
+): CoachIntentSnapshot {
+	const activeIds = new Set(scopedRows.map((row) => row.id));
+	const intentDataById = Object.fromEntries(
+		scopedRows.map((row) => [row.id, row as Record<string, unknown>]),
+	);
+	const quests = scopedRows
+		.map((row) => bountyFromCoachIntent(row.id, row, progress, playerUid))
+		.filter((b): b is QuestTask => b != null);
+	return { quests, intentDataById, activeIds };
+}
+
+export function coachIntentRemovalDelta(
+	lastIds: readonly string[],
+	activeIds: Set<string>,
+): { removed: string[]; nextIds: string[] } {
+	const removed = lastIds.filter((id) => !activeIds.has(id));
+	return { removed, nextIds: [...activeIds] };
+}
+
+export function applyCoachIntentPurge(
+	progress: QuestProgressStore,
+	removed: readonly string[],
+): QuestProgressStore {
+	if (removed.length === 0) return progress;
+	const next = purgeCoachIntentIds(progress, removed);
+	const handoff = readMissionHandoff();
+	if (handoff?.source === 'coach_intent' && removed.includes(handoff.missionId)) {
+		clearMissionHandoff();
+	}
+	return next;
+}
+
+/** One-shot team_assignments read for post-claims-refresh mission rail sync. */
+export async function fetchCoachIntentQuests(
+	db: Firestore,
+	teamId: string,
+	playerUid: string,
+	progress: QuestProgressStore,
+): Promise<CoachIntentSnapshot> {
+	const intentQ = query(
+		collection(db, 'team_assignments'),
+		where('teamId', '==', teamId),
+		where('status', '==', 'active'),
+		orderBy('priority', 'asc'),
+	);
+	const snap = await getDocs(intentQ);
+	const uniqueDocs = [...new Map(snap.docs.map((d) => [d.id, d])).values()];
+	const scopedRows = uniqueDocs
+		.map((d) => ({ id: d.id, ...d.data() }))
+		.filter((row) => intentAssignmentVisibleToPlayer(row, playerUid));
+	return mapCoachIntentRows(scopedRows, progress, playerUid);
+}
+
+export function mergeCoachIntentsIntoQuestLog(
+	coachIntents: readonly QuestTask[],
+	existing: readonly QuestTask[],
+	progress: QuestProgressStore,
+): QuestTask[] {
+	const nonCoach = existing.filter((q) => q.source !== 'coach_intent');
+	return sortQuestLog(
+		[...coachIntents, ...nonCoach].filter((q) => !progress.claimedIds.includes(q.id)),
+	);
+}
+
+export function applyCoachIntentRefetch(input: {
+	snapshot: CoachIntentSnapshot;
+	lastCoachIntentIds: readonly string[];
+	internalQuests: readonly QuestTask[];
+	questProgress: QuestProgressStore;
+}): {
+	lastCoachIntentIds: string[];
+	intentDataById: Record<string, Record<string, unknown>>;
+	internalQuests: QuestTask[];
+	questProgress: QuestProgressStore;
+} {
+	const { snapshot, lastCoachIntentIds, internalQuests, questProgress } = input;
+	const { removed, nextIds } = coachIntentRemovalDelta(lastCoachIntentIds, snapshot.activeIds);
+	return {
+		lastCoachIntentIds: nextIds,
+		intentDataById: snapshot.intentDataById,
+		questProgress: removed.length > 0 ? applyCoachIntentPurge(questProgress, removed) : questProgress,
+		internalQuests: mergeCoachIntentsIntoQuestLog(snapshot.quests, internalQuests, questProgress),
+	};
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Coach bounties created in **The Forge** (`team_assignments`) were not appearing on the player dashboard. The mission rail kept flickering between **SCANNING…** and **REFRESH/SYNC…** — an infinite retry loop.

## Root cause

`ActiveBounties` used `createMissionSnapshotRetryHandler()` **inside** a Svelte `$effect`. Each time `refreshNonce` or `claimsSyncNonce` bumped (after `refreshClaims()`), the effect re-ran, created a **new** retry handler with `retried = false`, and immediately retried again on the next Firestore permission error — never reaching the blocked state and never stabilizing the quest list.

Firestore `team_assignments` **list** rules also require both `tokenTeam()` **and** `tokenClub()` in the JWT. The claims-sync path only refreshed when `teamId` was stale, not when `clubId` was missing.

## Fix

- **`MissionSnapshotRetryGate`** — persistent retry state across effect re-runs; resets only on successful snapshot
- **Decouple subscriptions from claims refresh** — live `onSnapshot` listeners stay up; one-shot `getDocs` refetch runs in a separate effect after JWT refresh
- **Loading UX** — `hasQuestLogLoaded` prevents perpetual SCANNING flicker on claims-sync re-subscribes
- **Claims sync** — `refreshClaimsIfProfileTeamStale` now also checks profile `clubId` vs JWT `clubId`/`tenantId`
- **Extract** coach-intent fetch/merge helpers to `missionRailCoachIntents.ts` (file-budget compliant)

## Verification

```bash
npm test -- src/lib/player/dashboard/__tests__/missionRailAuth.test.ts src/lib/gamification/__tests__/personaFunctionalMvp.test.ts
npm run build
```

## QA notes

After deploy, verify as a player on a team with an active Forge intent:
1. Player dashboard mission rail loads without looping SCANNING/REFRESH
2. Coach bounty appears in **ACTIVE MISSIONS**
3. If claims were stale, one refresh cycle should recover without sign-out

If sync remains blocked after one retry, the existing **"Mission sync blocked — sign out and back in"** message still surfaces.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7ff6781-4b77-409c-95d4-ccc5049c3020"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7ff6781-4b77-409c-95d4-ccc5049c3020"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

