### PR TITLE
QA-142: Fix player dashboard not showing coach Forge missions after refresh

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -848,6 +848,40 @@ service cloud.firestore {
       );
     }
 
+    // Epic 8 — player intent read when JWT claims lag users/{email} (QA-142).
+    function playerIntentTeamOk(data) {
+      return (tokenTeam() != null && data.teamId == tokenTeam())
+        || (userDoc().keys().hasAll(['teamId']) && data.teamId == userDoc().teamId);
+    }
+
+    function playerIntentTenantOk(data) {
+      return (tokenClub() != null && data.tenantId == tokenClub())
+        || (userDoc().keys().hasAll(['clubId']) && data.tenantId == userDoc().clubId)
+        || (data.keys().hasAll(['teamId'])
+            && data.teamId != null
+            && exists(/databases/$(database)/documents/teams/$(data.teamId))
+            && userDoc().keys().hasAll(['clubId'])
+            && teamClubId(data.teamId) == userDoc().clubId);
+    }
+
+    function playerCanListTeamAssignment() {
+      return isPlayer()
+        && playerIntentTeamOk(resource.data)
+        && playerIntentTenantOk(resource.data);
+    }
+
+    function playerCanGetTeamAssignment() {
+      return isPlayer()
+        && resource.data.status == 'active'
+        && (
+          (resource.data.scope == 'team'
+            && playerIntentTeamOk(resource.data)
+            && playerIntentTenantOk(resource.data))
+          || (resource.data.scope == 'players'
+            && request.auth.uid in resource.data.targetUids)
+        );
+    }
+
     function canReadUsersDocument(userId) {
       return authed() && (
         emailKey() == userId.lower()
@@ -3729,27 +3763,14 @@ service cloud.firestore {
           && resource.data.tenantId == tokenClub()
         )
         // Player reads team-wide intent on their team
-        || (
-          isPlayer()
-          && resource.data.status == 'active'
-          && (
-            (resource.data.scope == 'team' && resource.data.teamId == tokenTeam())
-            || (resource.data.scope == 'players' && request.auth.uid in resource.data.targetUids)
-          )
-        )
+        || playerCanGetTeamAssignment()
       );
 
       allow list: if authed() && (
         isSuper()
         || (isCoach() || isDirector()) && tokenClub() != null
-        // T0-7: player list scoped to own team + tenant only (cross-tenant enumeration fix)
-        || (
-          isPlayer()
-          && tokenTeam() != null
-          && tokenClub() != null
-          && resource.data.teamId == tokenTeam()
-          && resource.data.tenantId == tokenClub()
-        )
+        // T0-7: player list scoped to own team + tenant (JWT or users/{email} fallback)
+        || playerCanListTeamAssignment()
       );
 
       // All writes are Admin SDK only (callable functions).

--- a/src/lib/player/dashboard/__tests__/missionRailAuth.test.ts
+++ b/src/lib/player/dashboard/__tests__/missionRailAuth.test.ts
@@ -1,5 +1,52 @@
-import { describe, it, expect, vi } from 'vitest';
-import { MissionSnapshotRetryGate } from '../missionRailAuth.js';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
+
+const { getIdTokenResult, refreshClaims } = vi.hoisted(() => ({
+	getIdTokenResult: vi.fn(),
+	refreshClaims: vi.fn(),
+}));
+
+vi.mock('$app/environment', () => ({ browser: true }));
+vi.mock('firebase/auth', () => ({ getIdTokenResult }));
+vi.mock('$lib/firebase.js', () => ({ auth: { currentUser: { uid: 'player-uid' } } }));
+vi.mock('$lib/stores/auth.svelte.js', () => ({ authStore: { refreshClaims } }));
+
+import { MissionSnapshotRetryGate, refreshClaimsIfProfileTeamStale } from '../missionRailAuth.js';
+
+describe('refreshClaimsIfProfileTeamStale', () => {
+	beforeEach(() => {
+		getIdTokenResult.mockReset();
+		refreshClaims.mockReset();
+		refreshClaims.mockResolvedValue(undefined);
+	});
+
+	it('refreshes when profile teamId is missing from JWT claims', async () => {
+		getIdTokenResult.mockResolvedValue({ claims: { clubId: 'club-a' } });
+		const refreshed = await refreshClaimsIfProfileTeamStale('team-a', 'club-a');
+		expect(refreshed).toBe(true);
+		expect(refreshClaims).toHaveBeenCalledOnce();
+	});
+
+	it('refreshes when JWT teamId differs from profile (QA-142)', async () => {
+		getIdTokenResult.mockResolvedValue({ claims: { teamId: 'team-b', clubId: 'club-a' } });
+		const refreshed = await refreshClaimsIfProfileTeamStale('team-a', 'club-a');
+		expect(refreshed).toBe(true);
+		expect(refreshClaims).toHaveBeenCalledOnce();
+	});
+
+	it('refreshes when JWT clubId differs from profile', async () => {
+		getIdTokenResult.mockResolvedValue({ claims: { teamId: 'team-a', clubId: 'club-b' } });
+		const refreshed = await refreshClaimsIfProfileTeamStale('team-a', 'club-a');
+		expect(refreshed).toBe(true);
+		expect(refreshClaims).toHaveBeenCalledOnce();
+	});
+
+	it('skips refresh when profile and JWT scope already match', async () => {
+		getIdTokenResult.mockResolvedValue({ claims: { teamId: 'team-a', clubId: 'club-a' } });
+		const refreshed = await refreshClaimsIfProfileTeamStale('team-a', 'club-a');
+		expect(refreshed).toBe(false);
+		expect(refreshClaims).not.toHaveBeenCalled();
+	});
+});
 
 describe('MissionSnapshotRetryGate', () => {
 	it('retries once then blocks', () => {

--- a/src/lib/player/dashboard/missionRailAuth.ts
+++ b/src/lib/player/dashboard/missionRailAuth.ts
@@ -30,7 +30,9 @@ export async function refreshClaimsIfProfileTeamStale(
 		const claimClub = claimClubId(tr.claims as Record<string, unknown>);
 		const teamStale = Boolean(teamId && !claimTeamId);
 		const clubStale = Boolean(clubId && !claimClub);
-		if (teamStale || clubStale) {
+		const teamMismatch = Boolean(teamId && claimTeamId && claimTeamId !== teamId);
+		const clubMismatch = Boolean(clubId && claimClub && claimClub !== clubId);
+		if (teamStale || clubStale || teamMismatch || clubMismatch) {
 			await authStore.refreshClaims();
 			return true;
 		}

--- a/src/lib/security/__tests__/firestoreRulesSprint22.test.ts
+++ b/src/lib/security/__tests__/firestoreRulesSprint22.test.ts
@@ -61,15 +61,17 @@ describe('T0-7 — team_assignments list rule tenant guard', () => {
 		expect(teamAssignmentsListBlock).toContain('allow list:');
 	});
 
-	it('list rule player branch requires tokenTeam() guard — own-team access only (T0-7)', () => {
-		// A player MUST be limited to their own team — bare isPlayer() is not sufficient.
-		expect(teamAssignmentsListBlock).toMatch(
-			/isPlayer\(\)[\s\S]*?resource\.data\.teamId\s*==\s*tokenTeam\(\)/,
-		);
+	it('list rule player branch uses playerCanListTeamAssignment — JWT + profile fallback (QA-142)', () => {
+		expect(teamAssignmentsListBlock).toContain('playerCanListTeamAssignment()');
+		expect(RULES).toMatch(/function playerIntentTeamOk\(data\)/);
+		expect(RULES).toMatch(/data\.teamId == tokenTeam\(\)/);
+		expect(RULES).toMatch(/data\.teamId == userDoc\(\)\.teamId/);
 	});
 
-	it('list rule player branch requires tenantId == tokenClub() guard — cross-tenant defence (T0-7)', () => {
-		expect(teamAssignmentsListBlock).toMatch(/resource\.data\.tenantId\s*==\s*tokenClub\(\)/);
+	it('list rule player branch requires tenant guard via playerIntentTenantOk (T0-7)', () => {
+		expect(RULES).toMatch(/function playerIntentTenantOk\(data\)/);
+		expect(RULES).toMatch(/data\.tenantId == tokenClub\(\)/);
+		expect(RULES).toMatch(/data\.tenantId == userDoc\(\)\.clubId/);
 	});
 
 	it('list rule player branch is NOT a bare isPlayer() call — regression guard (T0-7)', () => {

--- a/src/lib/security/__tests__/loopIntegrityGuards.test.ts
+++ b/src/lib/security/__tests__/loopIntegrityGuards.test.ts
@@ -239,6 +239,19 @@ describe.skipIf(!process.env.FIRESTORE_EMULATOR_HOST)(
 			await assertFails(getDoc(doc(db, 'team_assignments/intent-1')));
 		});
 
+		it('G2b: player with stale JWT but matching users/{email} profile reads intent — succeeds (QA-142)', async () => {
+			// JWT lacks teamId/clubId; users/player@club-a.com has team-a / club-a.
+			const db = env
+				.authenticatedContext('uid-player-a', token({
+					email: 'player@club-a.com',
+					role: 'player',
+					clubId: null,
+					teamId: null,
+				}))
+				.firestore();
+			await assertSucceeds(getDoc(doc(db, 'team_assignments/intent-1')));
+		});
+
 		// ── G3 — parentProvisionOperative seeded fields ──────────────────────────
 		// Rule: canReadUsersDocument → parentHouseholdAllowsChildEmail(userId.lower())
 		//   = isParent() && tokenHousehold()!=null && households/hh.playerEmails.hasAny([childKey])


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Coach missions deployed from The Forge **do land** in Firestore (`team_assignments` via `secureDeployIntent`). If the coach can see the intent in Forge `IntentArena`, the write succeeded.

Players were not seeing them after refresh because **read rules** required JWT `tokenTeam()` **and** `tokenClub()` to match each document. Player custom claims often lag `users/{email}` after roster link — profile has `teamId`/`clubId` but the token does not — so the `team_assignments` list query returned permission-denied or an empty set.

## Fix

1. **Firestore rules** — `playerIntentTeamOk` / `playerIntentTenantOk` helpers allow list/get when JWT matches **or** `users/{email}` profile matches (same team + tenant guards, no cross-team leak).
2. **`missionRailAuth.ts`** — refresh JWT when profile `teamId`/`clubId` **differs** from claims, not only when missing.
3. **Tests** — `missionRailAuth.test.ts`, updated `firestoreRulesSprint22.test.ts`, emulator guard G2b for stale-JWT scenario.

## Verify

```bash
npm test -- src/lib/player/dashboard/__tests__/missionRailAuth.test.ts src/lib/security/__tests__/firestoreRulesSprint22.test.ts src/lib/gamification/__tests__/personaFunctionalMvp.test.ts
npm run build
```

Deployed to `sports-skill-tracker-dev`: `firestore:rules` + `hosting`.

## QA

1. Coach deploys team-scoped intent in Forge → appears in Active Intents.
2. Player hard-refreshes dashboard → mission appears in Active Bounties without sync-blocked banner.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7ff6781-4b77-409c-95d4-ccc5049c3020"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7ff6781-4b77-409c-95d4-ccc5049c3020"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

