### PR TITLE
QA-142: Fix Start session not arming coach mission on Train page

### DIFF
--- a/src/lib/components/hud/ActiveBounties.svelte
+++ b/src/lib/components/hud/ActiveBounties.svelte
@@ -466,7 +466,8 @@
 		if (quest.source === 'coach_intent') {
 			const row = intentDataById[quest.id] ?? {};
 			const targetAttributeId =
-				typeof row.targetAttributeId === 'string' ? row.targetAttributeId.trim() : '';
+				(typeof row.targetAttributeId === 'string' ? row.targetAttributeId.trim() : '') ||
+				(typeof quest.targetAttributeId === 'string' ? quest.targetAttributeId.trim() : '');
 			const requiredXp = Math.max(0, Math.floor(Number(row.requiredXp) || 0));
 			const preview = drillPreviewByQuestId[quest.id];
 			const prescription = repairIntentPrescription(row.prescription);

--- a/src/lib/components/player/dashboard/__tests__/playerHudSprint314.test.ts
+++ b/src/lib/components/player/dashboard/__tests__/playerHudSprint314.test.ts
@@ -1,0 +1,26 @@
+/**
+ * playerHudSprint314.test.ts — QA-142 Train handoff: do not clear armed mission before Firestore loads
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = join(__dirname, '..', '..', '..', '..', '..');
+const WORKOUT = join(ROOT, 'routes/(app)/player/workout/+page.svelte');
+const ACTIVE_BOUNTIES = join(ROOT, 'lib/components/hud/ActiveBounties.svelte');
+
+const workoutSrc = existsSync(WORKOUT) ? readFileSync(WORKOUT, 'utf-8') : '';
+const bountiesSrc = existsSync(ACTIVE_BOUNTIES) ? readFileSync(ACTIVE_BOUNTIES, 'utf-8') : '';
+
+describe('QA-142 — coach mission Train handoff', () => {
+	it('workout page waits for team_assignments snapshot before clearing armed handoff', () => {
+		expect(workoutSrc).toMatch(/incomingMissionsReady/);
+		expect(workoutSrc).toMatch(/if \(!incomingMissionsReady\) return;/);
+		expect(workoutSrc).toMatch(/incomingMissionsReady = true;/);
+	});
+
+	it('ActiveBounties falls back to quest targetAttributeId when intent row cache is empty', () => {
+		expect(bountiesSrc).toMatch(/quest\.targetAttributeId/);
+	});
+});

--- a/src/routes/(app)/player/workout/+page.svelte
+++ b/src/routes/(app)/player/workout/+page.svelte
@@ -113,6 +113,7 @@
   let armedHandoff = $state(null);
   /** @type {Array<Record<string, unknown> & { id: string }>} */
   let incomingMissions = $state([]);
+  let incomingMissionsReady = $state(false);
   let missionSyncRefreshing = $state(false);
   let missionRefreshNonce = $state(0);
 
@@ -409,14 +410,13 @@
     };
   });
 
-  // Drop armed state if coach intent was cancelled server-side.
   $effect(() => {
     if (!armedHandoff || armedHandoff.source !== 'coach_intent') return;
+    if (!incomingMissionsReady) return;
     if (!incomingMissions.some((m) => m.id === armedHandoff.missionId)) {
       clearArmedMission();
     }
   });
-
   // Epic 8: subscribe to active team_assignments for HQ link + armed mission goal XP.
   $effect(() => {
     if (!browser) return;
@@ -427,8 +427,10 @@
       : '';
     if (authStore.role !== 'player' || !uid || !teamId) {
       incomingMissions = [];
+      incomingMissionsReady = false;
       return;
     }
+    incomingMissionsReady = false;
     const qy = query(
       collection(db, 'team_assignments'),
       where('teamId', '==', teamId),
@@ -445,6 +447,7 @@
           if (!m.scope || m.scope === 'team') return true;
           return Array.isArray(m.targetUids) && m.targetUids.includes(uid);
         });
+      incomingMissionsReady = true;
     };
     const unsub = onSnapshot(
       qy,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Coach missions appear on the player dashboard after the QA-142 rules fix, but **Start session →** opened Train without the armed mission. The handoff was stashed in `sessionStorage`, then immediately cleared.

## Root cause

Train page `$effect` checked `incomingMissions` before the first `team_assignments` snapshot arrived (`[]`). It treated that as “intent cancelled server-side” and called `clearArmedMission()`.

## Fix

- Add `incomingMissionsReady` — only clear armed handoff after a successful snapshot
- `stashQuestHandoff` falls back to `quest.targetAttributeId` when intent row cache is empty
- `playerHudSprint314.test.ts` regression guards

## Verify

```bash
npm test -- src/lib/components/player/dashboard/__tests__/playerHudSprint314.test.ts
npm run build
```

Deployed **hosting** to `sports-skill-tracker-dev`.

## QA

Dashboard → coach mission → Start session → Train shows coach mission panel (locked drill, goal XP).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7ff6781-4b77-409c-95d4-ccc5049c3020"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7ff6781-4b77-409c-95d4-ccc5049c3020"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

