### PR TITLE
QA-142: Start session arms coach drill on Train (skip readiness intercept)

### DIFF
--- a/src/lib/components/hud/ActiveBounties.svelte
+++ b/src/lib/components/hud/ActiveBounties.svelte
@@ -46,14 +46,12 @@
 	} from '$lib/player/dashboard/activeBounties.js';
 	import {
 		buildCoachHomeworkHandoff,
-		buildCoachIntentHandoff,
-		clearMissionHandoff,
 		COACH_INTENT_HINT,
 		formatSuggestedDrillLine,
 		readCachedPolicyHints,
-		readMissionHandoff,
 		resolveHeuristicDrill,
 		stashMissionHandoff,
+		stashCoachIntentHandoffForAssignment,
 	} from '$lib/player/workout/coachMissionFlow.js';
 	import { repairIntentPrescription } from '$lib/types/intent.js';
 	import '$lib/styles/active-bounties.css';
@@ -148,7 +146,8 @@
 				coachIntents.map(async (quest) => {
 					const row = rows[quest.id] ?? {};
 					const targetAttributeId =
-						typeof row.targetAttributeId === 'string' ? row.targetAttributeId.trim() : '';
+						(typeof row.targetAttributeId === 'string' ? row.targetAttributeId.trim() : '') ||
+						(typeof quest.targetAttributeId === 'string' ? quest.targetAttributeId.trim() : '');
 					if (!targetAttributeId) return;
 					const drill = await resolveHeuristicDrill(db, targetAttributeId, frustration);
 					if (!drill) return;
@@ -466,35 +465,27 @@
 		if (quest.source === 'coach_intent') {
 			const row = intentDataById[quest.id] ?? {};
 			const targetAttributeId =
-				typeof row.targetAttributeId === 'string' ? row.targetAttributeId.trim() : '';
+				(typeof row.targetAttributeId === 'string' ? row.targetAttributeId.trim() : '') ||
+				(typeof quest.targetAttributeId === 'string' ? quest.targetAttributeId.trim() : '');
 			const requiredXp = Math.max(0, Math.floor(Number(row.requiredXp) || 0));
 			const preview = drillPreviewByQuestId[quest.id];
 			const prescription = repairIntentPrescription(row.prescription);
-			const coachDrill =
-				prescription?.drillTitle ?
-					{
-						id:
-							prescription.teamDrillId ??
-							prescription.clubDrillId ??
-							preview?.id ??
-							'',
-						title: prescription.drillTitle,
-					}
-				: preview ?
-					{ id: preview.id, title: preview.title }
-				:	null;
-			stashMissionHandoff(
-				buildCoachIntentHandoff({
-					missionId: quest.id,
-					targetAttributeId,
-					requiredXp,
-					drill: coachDrill,
-					prescription,
-					durationMinutes: prescription?.targetDurationMin ?? null,
-					targetRpe: prescription?.targetRpe ?? null,
-					policyHints: readCachedPolicyHints(),
-				}),
-			);
+			const coachDrill = prescription?.drillTitle
+				? {
+					id: prescription.teamDrillId ?? prescription.clubDrillId ?? prescription.drillId ?? preview?.id ?? quest.id,
+					title: prescription.drillTitle,
+				}
+				: preview ? { id: preview.id, title: preview.title }
+				: targetAttributeId ? { id: quest.id, title: quest.title }
+				: null;
+			stashCoachIntentHandoffForAssignment({
+				missionId: quest.id,
+				targetAttributeId,
+				requiredXp,
+				prescription,
+				drill: coachDrill,
+				policyHints: readCachedPolicyHints(),
+			});
 			return;
 		}
 		if (quest.source === 'coach_homework') {
@@ -511,7 +502,12 @@
 	}
 
 	function shouldOpenMissionHeroModal(quest: QuestTask): boolean {
-		return quest.lifecycle === 'complete' && quest.actionHref.includes('/player/workout');
+		return (
+			quest.source !== 'coach_intent' &&
+			quest.source !== 'coach_homework' &&
+			quest.lifecycle === 'complete' &&
+			quest.actionHref.includes('/player/workout')
+		);
 	}
 
 	function formatMissionId(id: string): string {

--- a/src/lib/components/player/dashboard/__tests__/playerHudSprint314.test.ts
+++ b/src/lib/components/player/dashboard/__tests__/playerHudSprint314.test.ts
@@ -1,0 +1,42 @@
+/**
+ * playerHudSprint314.test.ts — QA-142 coach mission → Train handoff
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = join(__dirname, '..', '..', '..', '..', '..');
+const WORKOUT = join(ROOT, 'routes/(app)/player/workout/+page.svelte');
+const ACTIVE_BOUNTIES = join(ROOT, 'lib/components/hud/ActiveBounties.svelte');
+const ADAPTIVE_HW = join(ROOT, 'routes/(app)/player/dashboard/AdaptiveHomework.svelte');
+const FLOW = join(ROOT, 'lib/player/workout/coachMissionFlow.ts');
+
+const workoutSrc = existsSync(WORKOUT) ? readFileSync(WORKOUT, 'utf-8') : '';
+const bountiesSrc = existsSync(ACTIVE_BOUNTIES) ? readFileSync(ACTIVE_BOUNTIES, 'utf-8') : '';
+const adaptiveSrc = existsSync(ADAPTIVE_HW) ? readFileSync(ADAPTIVE_HW, 'utf-8') : '';
+const flowSrc = existsSync(FLOW) ? readFileSync(FLOW, 'utf-8') : '';
+
+describe('QA-142 — coach mission Train handoff', () => {
+	it('workout page waits for team_assignments snapshot before clearing armed handoff', () => {
+		expect(workoutSrc).toMatch(/incomingMissionsReady/);
+		expect(workoutSrc).toMatch(/if \(!incomingMissionsReady\) return;/);
+	});
+
+	it('coach missions skip MissionHeroModal and stash via stashCoachIntentHandoffForAssignment', () => {
+		expect(bountiesSrc).toMatch(/coach_intent.*coach_homework/s);
+		expect(bountiesSrc).toMatch(/return false/);
+		expect(bountiesSrc).toMatch(/stashCoachIntentHandoffForAssignment/);
+		expect(bountiesSrc).toMatch(/quest\.targetAttributeId/);
+	});
+
+	it('Morning Readiness defers when a coach Train handoff is pending', () => {
+		expect(adaptiveSrc).toMatch(/coachTrainHandoffPending/);
+		expect(adaptiveSrc).toMatch(/readMissionHandoff/);
+		expect(adaptiveSrc).toMatch(/showReadinessCard && !coachTrainHandoffPending/);
+	});
+
+	it('buildCoachIntentHandoff always carries a drillId fallback for execution panel', () => {
+		expect(flowSrc).toMatch(/input\.missionId/);
+	});
+});

--- a/src/lib/player/workout/__tests__/coachMissionFlow.test.ts
+++ b/src/lib/player/workout/__tests__/coachMissionFlow.test.ts
@@ -85,6 +85,14 @@ describe('coachMissionFlow', () => {
 		expect(read?.prescription?.repsPerSet).toBe(12);
 	});
 
+	it('buildCoachIntentHandoff falls back drillId to missionId when drill is unknown', () => {
+		const handoff = buildCoachIntentHandoff({
+			missionId: 'intent-fallback-1',
+			targetAttributeId: 'dribbling',
+		});
+		expect(handoff.drillId).toBe('intent-fallback-1');
+	});
+
 	it('resolveHandoffDurationMinutes prefers prescription over policy hints', () => {
 		const handoff = buildCoachIntentHandoff({
 			missionId: 'intent-rx-2',

--- a/src/lib/player/workout/coachMissionFlow.ts
+++ b/src/lib/player/workout/coachMissionFlow.ts
@@ -369,7 +369,12 @@ export function buildCoachIntentHandoff(input: {
 		:	undefined;
 	const drillTitle =
 		input.drill?.title ?? rx?.drillTitle ?? undefined;
-	const drillId = input.drill?.id ?? rx?.drillId ?? undefined;
+	const drillId =
+		input.drill?.id ??
+		rx?.drillId ??
+		rx?.teamDrillId ??
+		rx?.clubDrillId ??
+		input.missionId;
 	const videoUrl = rx?.videoUrl ?? undefined;
 	const cues = rx?.cues ?? undefined;
 	const cadence = rx?.cadence ?? undefined;

--- a/src/routes/(app)/player/dashboard/AdaptiveHomework.svelte
+++ b/src/routes/(app)/player/dashboard/AdaptiveHomework.svelte
@@ -10,10 +10,11 @@
 		getDoc,
 		setDoc,
 	} from 'firebase/firestore';
+	import { browser } from '$app/environment';
 	import { goto } from '$app/navigation';
 	import { httpsCallable } from 'firebase/functions';
 	import { db, functions } from '$lib/firebase.js';
-	import { stashCoachIntentHandoffForAssignment, buildPolicyHintsFromResult } from '$lib/player/workout/coachMissionFlow.js';
+	import { stashCoachIntentHandoffForAssignment, buildPolicyHintsFromResult, readMissionHandoff, isMissionHandoffStale } from '$lib/player/workout/coachMissionFlow.js';
 	import { ensureRlPolicyCached, readRlPolicyCache } from '$lib/player/workout/rlPolicyCache.js';
 	import { authStore } from '$lib/stores/auth.svelte.js';
 	import { sportsConfigStore } from '$lib/stores/sportsConfigStore.svelte.js';
@@ -70,6 +71,18 @@
 
 	// Morning Readiness Card — shown once per UTC day until player submits.
 	let showReadinessCard = $state(false);
+	let coachTrainHandoffPending = $state(false);
+
+	$effect(() => {
+		if (!browser) {
+			coachTrainHandoffPending = false;
+			return;
+		}
+		const handoff = readMissionHandoff();
+		coachTrainHandoffPending = Boolean(
+			handoff?.missionId && !isMissionHandoffStale(handoff),
+		);
+	});
 
 	$effect(() => {
 		const uid = authStore.user?.uid;
@@ -281,7 +294,7 @@
 	class="vanguard-surface tw-flex tw-flex-col tw-gap-5 tw-p-6"
 >
 	<!-- Morning Readiness Card (Phase 3, Epic 4 — RL S2) -->
-	{#if showReadinessCard}
+	{#if showReadinessCard && !coachTrainHandoffPending}
 		<MorningReadinessCard onSubmitted={() => { showReadinessCard = false; }} />
 		<div class="tw-w-full tw-h-px tw-bg-slate-800/60"></div>
 	{/if}

--- a/src/routes/(app)/player/workout/+page.svelte
+++ b/src/routes/(app)/player/workout/+page.svelte
@@ -113,6 +113,7 @@
   let armedHandoff = $state(null);
   /** @type {Array<Record<string, unknown> & { id: string }>} */
   let incomingMissions = $state([]);
+  let incomingMissionsReady = $state(false);
   let missionSyncRefreshing = $state(false);
   let missionRefreshNonce = $state(0);
 
@@ -252,16 +253,15 @@
     isBundleMode && bundleStepIdx === bundleDrills.length - 1,
   );
 
-  /**
-   * @param {MissionHandoff} handoff
-   */
   async function applyMissionHandoff(handoff) {
     if (isMissionHandoffStale(handoff)) {
       clearMissionHandoff();
       return;
     }
     activeMissionId = handoff.missionId;
-    armedHandoff = handoff;
+    let resolvedDrillTitle = handoff.drillTitle ?? '';
+    let resolvedDrillId = handoff.drillId ?? handoff.missionId;
+    const pickDrill = (title, id) => { selectedDrill = title; resolvedDrillTitle = title; resolvedDrillId = id; };
     if (handoff.focusArea) {
       selectedFocus = handoff.focusArea;
     } else if (handoff.targetAttributeId) {
@@ -283,17 +283,18 @@
       const row = teamId ?
         await resolveTeamLibraryDrill(db, teamId, drillId, clubId || undefined)
       :	null;
-      if (row?.title) selectedDrill = row.title;
+      if (row?.title) pickDrill(row.title, drillId);
     } else if (handoff.prescription?.drillId) {
       const drill = await resolveDrillById(db, handoff.prescription.drillId);
-      if (drill?.title) selectedDrill = drill.title;
+      if (drill?.title) pickDrill(drill.title, drill.id);
     } else if (handoff.drillTitle) {
-      selectedDrill = handoff.drillTitle;
+      pickDrill(handoff.drillTitle, resolvedDrillId);
     } else if (handoff.targetAttributeId) {
       const frustration = String(profile?.recentFrustration ?? 'low');
       const drill = await resolveHeuristicDrill(db, handoff.targetAttributeId, frustration);
-      if (drill?.title) selectedDrill = drill.title;
+      if (drill?.title) pickDrill(drill.title, drill.id);
     }
+    armedHandoff = { ...handoff, drillId: resolvedDrillId, drillTitle: resolvedDrillTitle || handoff.drillTitle };
     if (handoff.prescription) {
       workoutSets = handoff.prescription.sets;
       workoutRepsPerSet = handoff.prescription.repsPerSet ?? 0;
@@ -377,14 +378,12 @@
     });
   });
 
-  // RL inference on Train for non-coach sessions only (coach prescription is authoritative).
   $effect(() => {
     if (!browser) return;
     if (authStore.role !== 'player') return;
     const missionId = activeMissionId;
     if (!missionId) return;
     if (isCoachDirectedHandoff(armedHandoff?.source)) return;
-
     const sportId = sportsConfigStore.currentSportConfig?.sportId ?? 'soccer';
     let cancelled = false;
 
@@ -409,15 +408,14 @@
     };
   });
 
-  // Drop armed state if coach intent was cancelled server-side.
   $effect(() => {
     if (!armedHandoff || armedHandoff.source !== 'coach_intent') return;
+    if (!incomingMissionsReady) return;
     if (!incomingMissions.some((m) => m.id === armedHandoff.missionId)) {
       clearArmedMission();
     }
   });
 
-  // Epic 8: subscribe to active team_assignments for HQ link + armed mission goal XP.
   $effect(() => {
     if (!browser) return;
     void missionRefreshNonce;
@@ -427,8 +425,10 @@
       : '';
     if (authStore.role !== 'player' || !uid || !teamId) {
       incomingMissions = [];
+      incomingMissionsReady = false;
       return;
     }
+    incomingMissionsReady = false;
     const qy = query(
       collection(db, 'team_assignments'),
       where('teamId', '==', teamId),
@@ -445,6 +445,7 @@
           if (!m.scope || m.scope === 'team') return true;
           return Array.isArray(m.targetUids) && m.targetUids.includes(uid);
         });
+      incomingMissionsReady = true;
     };
     const unsub = onSnapshot(
       qy,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After coach missions appeared on HQ, **Start session →** did not arm the drill on Train. Users reported the **Morning Readiness** card appearing instead — that card lives in Adaptive Homework on the dashboard and was intercepting the flow when navigation stalled or the page re-rendered.

## Fix

1. **Coach missions skip MissionHeroModal** — Start session stashes handoff and navigates straight to `/player/workout`
2. **Richer handoff stash** — `stashCoachIntentHandoffForAssignment` with `quest.targetAttributeId` + drill preview fallbacks; `buildCoachIntentHandoff` always sets `drillId` (falls back to `missionId`)
3. **Train page** — wait for first `team_assignments` snapshot before clearing armed state; merge resolved drill into `armedHandoff` after heuristic/team drill lookup
4. **Adaptive Homework** — defer Morning Readiness while a coach Train handoff is pending in `sessionStorage`

## Verify

```bash
npm test -- src/lib/components/player/dashboard/__tests__/playerHudSprint314.test.ts src/lib/player/workout/__tests__/coachMissionFlow.test.ts
npm run build
```

Deployed hosting to `sports-skill-tracker-dev`.

## QA

HQ → coach mission → **Start session →** lands on Train with armed mission banner, locked focus/drill, and coach execution panel.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7ff6781-4b77-409c-95d4-ccc5049c3020"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7ff6781-4b77-409c-95d4-ccc5049c3020"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

