### PR TITLE
LAUNCH-forge: high-priority toggle replaces intent priority slider

### DIFF
--- a/src/lib/coach/intent/CoachIntentEngineView.svelte
+++ b/src/lib/coach/intent/CoachIntentEngineView.svelte
@@ -106,7 +106,7 @@
 					bind:draftDurationDays={engine.draftDurationDays}
 					bind:draftScope={engine.draftScope}
 					bind:draftTargetUids={engine.draftTargetUids}
-					bind:draftPriority={engine.draftPriority}
+					bind:draftHighPriority={engine.draftHighPriority}
 					bind:draftPrescriptionSets={engine.draftPrescriptionSets}
 					bind:draftPrescriptionRepsPerSet={engine.draftPrescriptionRepsPerSet}
 					bind:draftPrescriptionBilateral={engine.draftPrescriptionBilateral}

--- a/src/lib/coach/intent/IntentArena.svelte
+++ b/src/lib/coach/intent/IntentArena.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { isHighPriorityIntent } from '$lib/types/intent.js';
 	interface RosterRow {
 		uid: string;
 		playerName: string;
@@ -119,13 +120,15 @@
 						{intent.daysRemaining}d remaining
 					</span>
 
-					<!-- Priority badge -->
-					<span
-						class="tw-px-2 tw-py-0.5 tw-rounded tw-font-mono tw-text-[9px] tw-tracking-widest tw-uppercase
-						       tw-border tw-border-[#a855f7]/30 tw-text-[#a855f7]/70"
-					>
-						P{intent.priority}
-					</span>
+					<!-- Priority badge (high-priority toggle only) -->
+					{#if isHighPriorityIntent(intent.priority)}
+						<span
+							class="tw-px-2 tw-py-0.5 tw-rounded tw-font-mono tw-text-[9px] tw-tracking-widest tw-uppercase
+							       tw-border tw-border-[#fbbf24]/40 tw-text-[#fbbf24]/90"
+						>
+							Priority
+						</span>
+					{/if}
 				</div>
 
 				<!-- Progress bar -->

--- a/src/lib/coach/intent/IntentEngine.svelte.ts
+++ b/src/lib/coach/intent/IntentEngine.svelte.ts
@@ -42,7 +42,10 @@ import type {
 	ExtendIntentInput,
 	ExtendIntentResult,
 } from '$lib/types/intent.js';
-import { INTENT_MIGRATION_DEFAULTS } from '$lib/types/intent.js';
+import {
+	INTENT_MIGRATION_DEFAULTS,
+	priorityFromCoachToggle,
+} from '$lib/types/intent.js';
 import {
 	loadTeamDrillsForIntent,
 	type TeamDrillPickerRow,
@@ -87,7 +90,8 @@ export class IntentEngine {
 	draftDurationDays = $state(7);
 	draftScope = $state<IntentScope>('team');
 	draftTargetUids = $state<string[]>([]);
-	draftPriority = $state(100);
+	/** When true, deploys with high sort priority so players see the mission first. */
+	draftHighPriority = $state(false);
 	draftPrescriptionSets = $state(3);
 	draftPrescriptionRepsPerSet = $state(10);
 	draftPrescriptionBilateral = $state(false);
@@ -261,7 +265,7 @@ export class IntentEngine {
 		this.draftDurationDays = 7;
 		this.draftScope = 'team';
 		this.draftTargetUids = [];
-		this.draftPriority = 100;
+		this.draftHighPriority = false;
 		this.draftPrescriptionSets = 3;
 		this.draftPrescriptionRepsPerSet = 10;
 		this.draftPrescriptionBilateral = false;
@@ -392,7 +396,7 @@ export class IntentEngine {
 							this.roster.some((r) => r.rosterKey === key && r.assignable),
 						)
 					:	[],
-				priority: this.draftPriority,
+				priority: priorityFromCoachToggle(this.draftHighPriority),
 				prescription: this.buildDeployPrescription(),
 			});
 			this.deployPhase = 'success';

--- a/src/lib/coach/intent/IntentHUD.svelte
+++ b/src/lib/coach/intent/IntentHUD.svelte
@@ -20,7 +20,7 @@
 		draftDurationDays = $bindable(7),
 		draftScope = $bindable<'team' | 'players'>('team'),
 		draftTargetUids = $bindable<string[]>([]),
-		draftPriority = $bindable(100),
+		draftHighPriority = $bindable(false),
 		draftPrescriptionSets = $bindable(3),
 		draftPrescriptionRepsPerSet = $bindable(10),
 		draftPrescriptionBilateral = $bindable(false),
@@ -424,24 +424,33 @@
 		Player sees optional "Send proof" prompt after logging. Advisory — XP is never gated.
 	</p>
 
-	<!-- ── Priority (secondary row) ─────────────────── -->
-		<div class="tw-flex tw-items-center tw-gap-3">
-			<label for="hud-pri" class="tw-font-mono tw-text-[9px] tw-tracking-widest tw-text-[#14b8a6]/30 tw-uppercase tw-shrink-0">
-				PRIORITY
-			</label>
-			<input
-				id="hud-pri"
-				type="range"
-				min="1"
-				max="200"
-				step="5"
-				bind:value={draftPriority}
-				class="tw-flex-1 tw-accent-[#14b8a6] tw-h-px tw-cursor-pointer"
-			/>
-			<span class="tw-font-mono tw-text-[10px] tw-tracking-wider tw-text-[#14b8a6]/50 tw-w-8 tw-text-right tw-shrink-0">
-				{draftPriority}
-			</span>
-		</div>
+	<!-- ── High priority toggle ─────────────────────── -->
+	<div class="tw-flex tw-items-center tw-justify-between tw-gap-3">
+		<label for="hud-high-priority" class="tw-font-mono tw-text-[9px] tw-tracking-widest tw-text-[#14b8a6]/40 tw-uppercase tw-leading-relaxed">
+			High priority <span class="tw-text-white/20">(opt)</span>
+		</label>
+		<button
+			id="hud-high-priority"
+			type="button"
+			role="switch"
+			aria-checked={draftHighPriority}
+			onclick={() => (draftHighPriority = !draftHighPriority)}
+			class="tw-w-8 tw-h-4 tw-rounded-full tw-border tw-transition-all tw-shrink-0"
+			style={draftHighPriority
+				? 'background:rgba(251,191,36,0.25); border-color:#fbbf24;'
+				: 'background:transparent; border-color:rgba(20,184,166,0.2);'}
+		>
+			<span
+				class="tw-block tw-w-2.5 tw-h-2.5 tw-rounded-full tw-transition-transform"
+				style={draftHighPriority
+					? 'background:#fbbf24; transform:translateX(18px);'
+					: 'background:rgba(20,184,166,0.3); transform:translateX(2px);'}
+			></span>
+		</button>
+	</div>
+	<p class="tw-font-mono tw-text-[8px] tw-text-white/20 tw-leading-relaxed tw-mt-[-4px]">
+		Surfaces first on player dashboards with a priority alert.
+	</p>
 
 		<!-- ── Scope toggle ───────────────────────────────── -->
 		<div class="tw-flex tw-flex-col tw-gap-1.5">

--- a/src/lib/coach/intent/__tests__/intentModule.test.ts
+++ b/src/lib/coach/intent/__tests__/intentModule.test.ts
@@ -81,4 +81,19 @@ describe('LAUNCH-forge-nameonly — Intent Engine roster hints', () => {
 		expect(src).toMatch(/selectedAssignableCount/);
 		expect(src).toMatch(/nameOnlyRosterCount/);
 	});
+
+	it('IntentHUD uses high-priority toggle instead of numeric priority slider', () => {
+		const hud = readFileSync(HUD, 'utf-8');
+		expect(hud).toMatch(/draftHighPriority/);
+		expect(hud).toMatch(/role="switch"/);
+		expect(hud).toMatch(/hud-high-priority/);
+		expect(hud).not.toMatch(/hud-pri/);
+		expect(hud).not.toMatch(/bind:value=\{draftPriority\}/);
+	});
+
+	it('IntentEngine maps high-priority toggle to sort rank on deploy', () => {
+		const src = readFileSync(ENGINE, 'utf-8');
+		expect(src).toMatch(/draftHighPriority/);
+		expect(src).toMatch(/priorityFromCoachToggle/);
+	});
 });

--- a/src/lib/components/hud/ActiveBounties.svelte
+++ b/src/lib/components/hud/ActiveBounties.svelte
@@ -32,6 +32,7 @@
 		maxVisibleQuests,
 		formatQuestRewardLabel,
 		isPromotedQuest,
+		isHighPriorityCoachQuest,
 		questCtaLabel,
 		shouldDeferQuestCompletionUntilWorkoutLog,
 		questHudCtaFor,
@@ -626,6 +627,7 @@
 		class:quest-row--bounty={quest.tier === 'bounty'}
 		class:quest-row--hero={heroQuest?.id === quest.id}
 		class:quest-row--promoted={!heroQuest && isPromotedQuest(quest)}
+		class:quest-row--high-priority={isHighPriorityCoachQuest(quest)}
 	>
 		{#if quest.lifecycle === 'accept'}
 			<span class="quest-row__status" aria-hidden="true"></span>
@@ -648,6 +650,7 @@
 			{/if}
 			{#if quest.source === 'coach_intent'}
 				<p class="quest-row__hint">{COACH_INTENT_HINT}</p>
+				{#if quest.isHighPriority}<span class="quest-row__priority-alert" aria-label="Coach priority mission">Priority</span>{/if}
 				{#if drillPreviewByQuestId[quest.id]?.line}
 					<p class="quest-row__drill">{drillPreviewByQuestId[quest.id].line}</p>
 				{/if}

--- a/src/lib/player/dashboard/__tests__/activeBounties.test.ts
+++ b/src/lib/player/dashboard/__tests__/activeBounties.test.ts
@@ -47,6 +47,25 @@ describe('activeBounties', () => {
 		expect(sortQuestLog([daily, bounty])[0]?.tier).toBe('bounty');
 	});
 
+	it('marks coach intents as high priority when sort rank is below normal', () => {
+		const progress = { acceptedIds: [], completedIds: [], claimedIds: [], claimedDateUtc: '2026-01-01' };
+		const high = bountyFromCoachIntent(
+			'i-high',
+			{ targetAttributeId: 'pace', requiredXp: 200, priority: 1 },
+			progress,
+		)!;
+		const normal = bountyFromCoachIntent(
+			'i-normal',
+			{ targetAttributeId: 'pace', requiredXp: 200, priority: 100 },
+			progress,
+		)!;
+		expect(high.isHighPriority).toBe(true);
+		expect(high.sortKey).toBe(1);
+		expect(normal.isHighPriority).toBe(false);
+		expect(normal.sortKey).toBe(100);
+		expect(sortQuestLog([normal, high])[0]?.id).toBe('i-high');
+	});
+
 	it('maps lifecycle to CTA labels', () => {
 		expect(questCtaLabel('accept')).toBe('Accept');
 		expect(questCtaLabel('complete')).toBe('Complete');
@@ -421,6 +440,18 @@ describe('B4b — advisory parent-verified badge: bountyFromCoachIntent is unaff
 		);
 		expect(AB_SRC).toMatch(/quest-row__parent-verified/);
 		expect(AB_SRC).toMatch(/approvedIntentIds\.has\(quest\.id\)/);
+	});
+
+	it('source-scan: ActiveBounties.svelte shows priority alert for high-priority coach intents', () => {
+		const { readFileSync } = require('fs');
+		const { join } = require('path');
+		const AB_SRC = readFileSync(
+			join(__dirname, '../../../components/hud/ActiveBounties.svelte'),
+			'utf-8',
+		);
+		expect(AB_SRC).toMatch(/quest-row__priority-alert/);
+		expect(AB_SRC).toMatch(/quest\.isHighPriority/);
+		expect(AB_SRC).toMatch(/quest-row--high-priority/);
 	});
 
 	it('source-scan: badge does NOT alter xpReward, lifecycle, or sortKey (advisory only)', () => {

--- a/src/lib/player/dashboard/activeBounties.ts
+++ b/src/lib/player/dashboard/activeBounties.ts
@@ -2,6 +2,7 @@
  * Quest log model — dailies + coach/parent bounties for Player OS dashboard.
  */
 
+import { isHighPriorityIntent } from '$lib/types/intent.js';
 import { isTrainingToday } from './playerHudMetrics.js';
 import type { VanguardAxisId } from './vanguardProtocol.js';
 
@@ -25,6 +26,8 @@ export type QuestTask = {
 	actionHref: string;
 	/** Lower = surfaced earlier within the same tier. */
 	sortKey: number;
+	/** Coach marked high priority in The Forge — surfaces first with alert styling. */
+	isHighPriority?: boolean;
 	/**
 	 * Per-assignment cadence config when coach set one.
 	 * Distinct from the global streak — do NOT reuse streak chrome/labels.
@@ -173,6 +176,11 @@ export function formatQuestRewardLabel(quest: QuestTask): string {
 /** @deprecated Slice 6b-revise — embedded UI uses rail-only feed; retained for tests. */
 export function splitEmbeddedMissionDeck(deck: readonly QuestTask[]) {
 	return { primary: deck[0] ?? null, secondary: deck.slice(1) };
+}
+
+/** Coach intent flagged high priority in The Forge. */
+export function isHighPriorityCoachQuest(quest: QuestTask): boolean {
+	return quest.source === 'coach_intent' && quest.isHighPriority === true;
 }
 
 /** Coach/parent bounty or tier bounty — gold rail accent on HQ overview. */
@@ -539,6 +547,7 @@ export function bountyFromCoachIntent(
 		actionHref: '/player/workout',
 		sortKey: priority,
 		targetAttributeId,
+		isHighPriority: isHighPriorityIntent(priority),
 		...(cadence ? { cadence } : {}),
 	};
 }

--- a/src/lib/styles/active-bounties.css
+++ b/src/lib/styles/active-bounties.css
@@ -400,6 +400,23 @@
 	background: rgba(20, 184, 166, 0.06);
 }
 
+/* Coach high-priority toggle — gold alert on player mission rail */
+.quest-row__priority-alert {
+	display: inline-block;
+	margin-top: 0.25rem;
+	margin-right: 0.35rem;
+	padding: 0.1rem 0.4rem;
+	font-size: 0.5rem;
+	font-weight: 700;
+	letter-spacing: 0.12em;
+	text-transform: uppercase;
+	color: rgba(251, 191, 36, 0.95);
+	border: 1px solid rgba(251, 191, 36, 0.45);
+	border-radius: 3px;
+	background: rgba(251, 191, 36, 0.08);
+	box-shadow: 0 0 12px rgba(251, 191, 36, 0.15);
+}
+
 @media (max-width: 640px) {
 	.quest-row {
 		flex-wrap: wrap;

--- a/src/lib/styles/player-missions.css
+++ b/src/lib/styles/player-missions.css
@@ -713,6 +713,17 @@
 		0 2px 6px rgba(0, 0, 0, 0.28);
 }
 
+.player-hud-root .quest-row--rail.quest-row--embedded.quest-row--high-priority {
+	box-shadow:
+		inset 0 1px 0 rgba(255, 255, 255, 0.05),
+		0 0 18px rgba(251, 191, 36, 0.12),
+		0 2px 8px rgba(0, 0, 0, 0.3);
+}
+
+.player-hud-root .quest-row--rail.quest-row--embedded.quest-row--high-priority .quest-row__sender {
+	color: color-mix(in srgb, var(--pd-accent-action, #fbbf24) 78%, #f8fafc);
+}
+
 /* Player OS Wave B — single gold hero mission row (SDT competence focal; idle CTA owns gold) */
 .player-hud-root .quest-row--rail.quest-row--embedded.quest-row--hero {
 	border-left-width: 3px;

--- a/src/lib/types/intent.ts
+++ b/src/lib/types/intent.ts
@@ -203,6 +203,19 @@ export const INTENT_MIGRATION_DEFAULTS: Partial<IntentDoc> = {
   intentVersion: 1,
 };
 
+/** Default sort rank for normal coach intents (lower = surfaced first). */
+export const INTENT_PRIORITY_NORMAL = 100;
+/** Sort rank when coach marks intent as high priority in The Forge. */
+export const INTENT_PRIORITY_HIGH = 1;
+
+export function isHighPriorityIntent(priority: number): boolean {
+  return Number.isFinite(priority) && priority < INTENT_PRIORITY_NORMAL;
+}
+
+export function priorityFromCoachToggle(highPriority: boolean): number {
+  return highPriority ? INTENT_PRIORITY_HIGH : INTENT_PRIORITY_NORMAL;
+}
+
 /**
  * Repair a single bundle drill entry (B3). Same per-field guards as the
  * top-level prescription — sets required int 1–99; other fields optional.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Replaces the numeric **Priority** slider in The Forge with an optional **High priority** toggle (matches owner QA Phase 5 intent).
- Deploy maps toggle → sort rank (`1` high / `100` normal) via `priorityFromCoachToggle`.
- Player mission rail surfaces high-priority coach intents first (existing sort) and adds a gold **Priority** badge + emphasis styling.

## Test plan
- [x] `npm test -- src/lib/coach/intent/__tests__/intentModule.test.ts src/lib/player/dashboard/__tests__/activeBounties.test.ts`
- [x] `npm run build`
- [x] `firebase deploy --only hosting` → sports-skill-tracker-dev
- [ ] Coach Forge: toggle high priority on deploy; confirm no slider
- [ ] Player HQ: priority mission shows gold badge and sorts above normal coach intents
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7ff6781-4b77-409c-95d4-ccc5049c3020"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7ff6781-4b77-409c-95d4-ccc5049c3020"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

