### PR TITLE
Train: move pre-session readiness strip to top of workout page

### DIFF
--- a/src/lib/components/player/dashboard/__tests__/playerHudSprint314.test.ts
+++ b/src/lib/components/player/dashboard/__tests__/playerHudSprint314.test.ts
@@ -44,6 +44,10 @@ describe('QA-142 — coach mission Train handoff', () => {
 		expect(workoutSrc).toMatch(/useTrainReadinessStrip/);
 		expect(readinessHook).toMatch(/physio_self_reports/);
 		expect(readinessHook).toMatch(/physioForTransmit/);
+		const stripIdx = workoutSrc.indexOf('TrainReadinessStrip');
+		const transmitIdx = workoutSrc.indexOf('pw-theater__transmit');
+		expect(stripIdx).toBeGreaterThan(-1);
+		expect(transmitIdx).toBeGreaterThan(stripIdx);
 	});
 
 	it('logTrainingSession writes drill_completions for cadence when attributeId is set', () => {

--- a/src/lib/gamification/__tests__/playerRlFunctional.test.ts
+++ b/src/lib/gamification/__tests__/playerRlFunctional.test.ts
@@ -173,6 +173,12 @@ describe('Sprint RL-transition-guards — transition pipeline wiring', () => {
 		expect(src).toMatch(/TrainReadinessStrip/);
 		expect(src).toMatch(/useTrainReadinessStrip/);
 		expect(hook).toMatch(/physioForTransmit/);
+		const stripIdx = src.indexOf('TrainReadinessStrip');
+		const transmitIdx = src.indexOf('pw-theater__transmit');
+		const configureIdx = src.indexOf('Configure session');
+		expect(stripIdx).toBeGreaterThan(-1);
+		expect(transmitIdx).toBeGreaterThan(stripIdx);
+		expect(configureIdx).toBeGreaterThan(stripIdx);
 	});
 });
 

--- a/src/lib/player/workout/TrainReadinessStrip.svelte
+++ b/src/lib/player/workout/TrainReadinessStrip.svelte
@@ -92,7 +92,7 @@
 
 <style>
 	.pw-readiness {
-		margin-top: 0.75rem;
+		margin: 0 0 0.75rem;
 		padding: 0.85rem 1rem;
 		border: 1px solid rgba(20, 184, 166, 0.22);
 		background: rgba(20, 184, 166, 0.05);

--- a/src/routes/(app)/player/workout/+page.svelte
+++ b/src/routes/(app)/player/workout/+page.svelte
@@ -782,6 +782,14 @@
 
   <div class="pw-theater pd-os-deck pd-os-deck--hero bento-span-12">
     <div class="pw-theater__z4-scan" aria-hidden="true"></div>
+    {#if trainReadiness.showReadinessStrip}
+      <TrainReadinessStrip
+        bind:sleepHoursLastNight={trainReadiness.readinessSleepHours}
+        bind:soreness={trainReadiness.readinessSoreness}
+        bind:mood={trainReadiness.readinessMood}
+        bind:restingFeel={trainReadiness.readinessRestingFeel}
+      />
+    {/if}
     {#if activeMissionId}
       <div class="pw-mission-armed pd-os-deck__well" aria-live="polite">
         <div class="pw-mission-armed__head">
@@ -1124,15 +1132,6 @@
         </div>
       </div>
     </div>
-
-    {#if trainReadiness.showReadinessStrip}
-      <TrainReadinessStrip
-        bind:sleepHoursLastNight={trainReadiness.readinessSleepHours}
-        bind:soreness={trainReadiness.readinessSoreness}
-        bind:mood={trainReadiness.readinessMood}
-        bind:restingFeel={trainReadiness.readinessRestingFeel}
-      />
-    {/if}
 
     <div class="pw-theater__transmit">
       {#if isBundleMode}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Moves the **Pre-session check** readiness strip from the bottom of `/player/workout` (just above EXEC_COMMIT) to the **top of the train theater** — before armed mission, configure session, and transmit.

## Why
Pre-session gauges (sleep, soreness, mood, starting readiness) belong at session start, not after RPE/duration controls where they read like a post-workout debrief.

## Test plan
- [x] `npm test -- src/lib/gamification/__tests__/playerRlFunctional.test.ts src/lib/components/player/dashboard/__tests__/playerHudSprint314.test.ts`
- [x] `npm run build`
- [x] `firebase deploy --only hosting`
- [ ] Player Train (first session of day): readiness strip appears at top of page
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7ff6781-4b77-409c-95d4-ccc5049c3020"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7ff6781-4b77-409c-95d4-ccc5049c3020"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

