### PR TITLE
LAUNCH-homework: per-day cadence intelligence + mission XP tracking

### DIFF
--- a/functions/src/domains/__tests__/trackB2Cadence.guard.test.js
+++ b/functions/src/domains/__tests__/trackB2Cadence.guard.test.js
@@ -167,4 +167,18 @@ describe('B2 — intent lifecycle cadence fulfillment gate (source-scan)', () =>
     assert.match(SRC, /source: 'logTrainingSession'/);
     assert.match(SRC, /restingFeel != null/);
   });
+
+  it('counts cadence sessions as distinct UTC days', () => {
+    assert.match(SRC, /days\.add\(new Date\(ms\)\.toISOString\(\)\.slice\(0, 10\)\)/);
+  });
+
+  it('writes at most one drill_completions row per attribute per UTC day', () => {
+    assert.match(SRC, /cadence_day_marks/);
+    assert.match(SRC, /!cadenceMarkSnap\.exists/);
+  });
+
+  it('tracks intent-scoped XP on team_assignments.intentXpByUid', () => {
+    assert.match(SRC, /intentXpByUid/);
+    assert.match(SRC, /intentXpMap != null/);
+  });
 });

--- a/functions/src/domains/trainingOps.js
+++ b/functions/src/domains/trainingOps.js
@@ -739,6 +739,12 @@ exports.logTrainingSession = onCall(LAUNCH_CORE_CALLABLE_OPTS, async (request) =
   const psRef = db().collection('player_stats').doc(athleteUid);
   const tsRef = teamId ? db().collection('team_stats').doc(teamId) : null;
   const teamRef = teamId ? db().collection('teams').doc(teamId) : null;
+  const intentRef = intentIdRaw ?
+    db().collection('team_assignments').doc(intentIdRaw) :
+    null;
+  const cadenceMarkRef = attributeIdRaw ?
+    db().collection('cadence_day_marks').doc(`${athleteUid}_${attributeIdRaw}_${todayStr}`) :
+    null;
 
   /**
    * @type {{
@@ -760,6 +766,8 @@ exports.logTrainingSession = onCall(LAUNCH_CORE_CALLABLE_OPTS, async (request) =
     const uSnapTx = await tx.get(uRef);
     const tsSnap = tsRef ? await tx.get(tsRef) : null;
     const teamSnap = teamRef ? await tx.get(teamRef) : null;
+    const intentSnap = intentRef ? await tx.get(intentRef) : null;
+    const cadenceMarkSnap = cadenceMarkRef ? await tx.get(cadenceMarkRef) : null;
     if (!uSnapTx.exists) {
       throw new HttpsError(
           'failed-precondition',
@@ -884,6 +892,8 @@ exports.logTrainingSession = onCall(LAUNCH_CORE_CALLABLE_OPTS, async (request) =
     };
     if (sessionNotes) logDoc.sessionNotes = sessionNotes;
     if (assignmentIdRaw) logDoc.assignmentId = assignmentIdRaw;
+    if (intentIdRaw) logDoc.intentId = intentIdRaw;
+    if (attributeIdRaw) logDoc.attributeId = attributeIdRaw;
     if (verifiedByUid) {
       logDoc.verifiedByUid = verifiedByUid;
       logDoc.verifiedByEmail = verifiedByEmail;
@@ -961,8 +971,8 @@ exports.logTrainingSession = onCall(LAUNCH_CORE_CALLABLE_OPTS, async (request) =
             uTxData.clubId.trim() :
             null);
 
-    // B2 cadence: audit row feeds HQ progress + intent lifecycle session gate.
-    if (attributeIdRaw) {
+    // B2 cadence: one session tick per UTC day per attribute (XP still awards every log).
+    if (attributeIdRaw && cadenceMarkRef && cadenceMarkSnap && !cadenceMarkSnap.exists) {
       const dcRef = db().collection('drill_completions').doc();
       const dcDoc = {
         playerUid: athleteUid,
@@ -978,7 +988,23 @@ exports.logTrainingSession = onCall(LAUNCH_CORE_CALLABLE_OPTS, async (request) =
         workoutLogId: logId,
       };
       if (intentIdRaw) dcDoc.intentId = intentIdRaw;
+      tx.set(cadenceMarkRef, {
+        playerUid: athleteUid,
+        attributeId: attributeIdRaw,
+        dateUtc: todayStr,
+        intentId: intentIdRaw || null,
+        workoutLogId: logId,
+        createdAt: now,
+      });
       tx.set(dcRef, dcDoc);
+    }
+
+    // Intent-scoped XP progress (mission delta — not lifetime attribute total).
+    if (intentIdRaw && intentRef && intentSnap && intentSnap.exists) {
+      tx.update(intentRef, {
+        [`intentXpByUid.${athleteUid}`]: admin.firestore.FieldValue.increment(earned),
+        updatedAt: now,
+      });
     }
 
     // RL physio: first workout log of the UTC day mirrors daily self-report (Train strip).
@@ -2254,6 +2280,7 @@ exports.secureDeployIntent = onCall(LAUNCH_CORE_CALLABLE_OPTS, async (request) =
     priority,
     status: 'active',
     fulfilledByUids: [],
+    intentXpByUid: {},
     intentVersion: 1,
     createdAt: admin.firestore.FieldValue.serverTimestamp(),
     expiresAt,
@@ -2631,7 +2658,20 @@ async function countCadenceSessionsForAttribute(uid, attributeId, windowDays) {
       .where('playerUid', '==', uid)
       .where('loggedAt', '>=', windowStart)
       .get();
-  return snap.docs.filter((d) => d.data().attributeId === attributeId).length;
+  const days = new Set();
+  for (const d of snap.docs) {
+    const data = d.data();
+    if (data.attributeId !== attributeId) continue;
+    const loggedAt = data.loggedAt;
+    let ms = Date.now();
+    if (loggedAt && typeof loggedAt.toMillis === 'function') {
+      ms = loggedAt.toMillis();
+    } else if (loggedAt instanceof Date) {
+      ms = loggedAt.getTime();
+    }
+    days.add(new Date(ms).toISOString().slice(0, 10));
+  }
+  return days.size;
 }
 
 /**
@@ -2670,7 +2710,15 @@ async function tryFulfillActiveIntentsForPlayer(input) {
     if (!inScope) continue;
 
     const requiredXp = Number(intent.requiredXp) || 0;
-    const playerXp = Number(xpByAttribute[attrId] || 0);
+    const intentXpMap =
+      intent.intentXpByUid &&
+      typeof intent.intentXpByUid === 'object' &&
+      !Array.isArray(intent.intentXpByUid) ?
+        intent.intentXpByUid :
+        null;
+    const playerXp = intentXpMap != null ?
+      Number(intentXpMap[uid] || 0) :
+      Number(xpByAttribute[attrId] || 0);
     if (playerXp < requiredXp) continue;
 
     const cadence = cadenceFromIntentPrescription(intent.prescription);

--- a/src/lib/coach/intent/IntentEngine.svelte.ts
+++ b/src/lib/coach/intent/IntentEngine.svelte.ts
@@ -307,7 +307,8 @@ export class IntentEngine {
 		}
 		const sessionsPerWindow = Math.floor(Number(this.draftCadenceSessionsPerWindow) || 0);
 		if (sessionsPerWindow >= 1 && sessionsPerWindow <= 21) {
-			rx.cadence = { sessionsPerWindow, windowDays: 7 };
+			const windowDays = Math.min(30, Math.max(1, Math.floor(Number(this.draftDurationDays) || 7)));
+			rx.cadence = { sessionsPerWindow, windowDays };
 		}
 		// B4a: emit requiresParentVerification only when coach opts in.
 		if (this.draftRequiresParentVerification === true) {

--- a/src/lib/components/hud/ActiveBounties.svelte
+++ b/src/lib/components/hud/ActiveBounties.svelte
@@ -24,7 +24,9 @@
 		bountyFromHomeworkAssignment,
 		bountyFromParentBounty,
 		countCadenceSessionsInWindow,
+		coachIntentRailCta,
 		formatCadenceProgress,
+		formatCadenceResumeHint,
 		loadQuestProgress,
 		markQuestAccepted,
 		markQuestClaimed,
@@ -89,13 +91,7 @@
 	const missionClaimsSync = new MissionRailClaimsSync();
 	const missionRetryGate = new MissionSnapshotRetryGate();
 	let lastCoachIntentIds = $state<string[]>([]);
-	/** Flat completion records for cadence progress — fetched once per uid, not real-time. */
-	let cadenceCompletions = $state<Array<{ attributeId: string; loggedAtMs: number }>>([]);
-	/**
-	 * B4b advisory badge: intentIds that have an 'approved' completion_verifications record
-	 * for this player. Subscribed player-own only (playerUid == auth.uid). Read-only display —
-	 * does NOT affect XP, progress, or intent fulfilment.
-	 */
+	let cadenceCompletions = $state<Array<{ attributeId: string; loggedAtMs: number; intentId?: string }>>([]);
 	let approvedIntentIds = $state<Set<string>>(new Set());
 	let missionModalQuest = $state<QuestTask | null>(null);
 
@@ -179,10 +175,8 @@
 		if (!browser || authStore.isLoading || authStore.role !== 'player') return;
 		const uid = authStore.user?.uid ?? '';
 		if (!uid) return;
-		const hasCadenceQuests = dedupedQuests.some(
-			(q) => q.source === 'coach_intent' && q.cadence,
-		);
-		if (!hasCadenceQuests) return;
+		const hasCoachIntentQuests = dedupedQuests.some((q) => q.source === 'coach_intent');
+		if (!hasCoachIntentQuests) return;
 		const windowStart = Timestamp.fromMillis(Date.now() - 30 * 86_400_000);
 		const q = query(
 			collection(db, 'drill_completions'),
@@ -204,7 +198,11 @@
 								: typeof ts?.seconds === 'number'
 									? ts.seconds * 1000
 									: 0;
-					return { attributeId: attrId, loggedAtMs: ms };
+					return {
+						attributeId: attrId,
+						loggedAtMs: ms,
+						intentId: typeof data.intentId === 'string' ? data.intentId : undefined,
+					};
 				});
 			},
 			() => {
@@ -214,8 +212,7 @@
 		return unsub;
 	});
 
-	// B4b — subscribe to player's own approved completion_verifications for advisory badge.
-	// Reads are player-own only (playerUid == auth.uid); no XP or progress logic is touched.
+	// B4b — approved completion_verifications (advisory badge only).
 	$effect(() => {
 		if (!browser || authStore.isLoading || authStore.role !== 'player') return;
 		const uid = authStore.user?.uid ?? '';
@@ -552,8 +549,8 @@
 		missionModalQuest = null;
 	}
 
-	/** @param {QuestTask} quest */
 	function handleQuestAction(quest: QuestTask) {
+		if (coachIntentRailCta(quest, cadenceCompletions).disabled) return;
 		if (quest.lifecycle === 'accept') {
 			questProgress = markQuestAccepted(quest.id, questProgress);
 			if (quest.source === 'coach_intent' || quest.source === 'coach_homework') {
@@ -620,12 +617,14 @@
 {/snippet}
 
 {#snippet questRowEmbedded(quest: QuestTask)}
+	{@const rail = coachIntentRailCta(quest, cadenceCompletions)}
 	<div
 		class="hud-bounty-row quest-row quest-row--embedded quest-row--premium quest-row--rail"
 		class:quest-row--habit={quest.tier === 'daily'}
 		class:quest-row--bounty={quest.tier === 'bounty'}
 		class:quest-row--hero={heroQuest?.id === quest.id}
 		class:quest-row--promoted={!heroQuest && isPromotedQuest(quest)}
+		class:quest-row--logged-today={rail.loggedToday}
 	>
 		{#if quest.lifecycle === 'accept'}
 			<span class="quest-row__status" aria-hidden="true"></span>
@@ -659,7 +658,13 @@
 					)}
 					<p class="quest-row__cadence pw-mono" aria-label="Cadence progress">
 						{formatCadenceProgress(completed, quest.cadence.sessionsPerWindow, quest.cadence.windowDays)}
+						{#if formatCadenceResumeHint(rail.loggedToday, completed, quest.cadence.sessionsPerWindow)}
+							· {formatCadenceResumeHint(rail.loggedToday, completed, quest.cadence.sessionsPerWindow)}
+						{/if}
 					</p>
+				{/if}
+				{#if quest.intentXpEarned != null}
+					<p class="quest-row__intent-xp pw-mono">{quest.intentXpEarned.toLocaleString()} / {quest.xpReward.toLocaleString()} mission XP</p>
 				{/if}
 				{#if approvedIntentIds.has(quest.id)}
 					<span class="quest-row__parent-verified" aria-label="Parent-verified">
@@ -682,10 +687,11 @@
 			class:quest-row__cmd--accept={quest.lifecycle === 'accept'}
 			class:quest-row__cmd--complete={quest.lifecycle === 'complete'}
 			class:quest-row__cmd--claim={quest.lifecycle === 'claim'}
+			disabled={rail.disabled}
 			aria-label={questCtaLabel(quest.lifecycle)}
 			onclick={() => handleQuestAction(quest)}
 		>
-			{questHudCtaFor(quest)}
+			{rail.label}
 		</button>
 	</div>
 {/snippet}
@@ -839,7 +845,5 @@
 	missionId={missionModalQuest ? formatMissionId(missionModalQuest.id) : ''}
 	title={missionModalQuest?.title ?? ''}
 	readout={missionModalQuest ? buildMissionModalReadout(missionModalQuest) : ''}
-	onEngage={engageMissionModal}
-	onTerminate={terminateMissionModal}
+	onEngage={engageMissionModal} onTerminate={terminateMissionModal}
 />
-

--- a/src/lib/player/dashboard/__tests__/activeBounties.test.ts
+++ b/src/lib/player/dashboard/__tests__/activeBounties.test.ts
@@ -5,7 +5,10 @@ import {
 	bountyFromCoachIntent,
 	buildDailyQuests,
 	countCadenceSessionsInWindow,
+	coachIntentCtaDisabled,
+	coachIntentSessionLoggedToday,
 	formatCadenceProgress,
+	formatCadenceResumeHint,
 	questCtaLabel,
 	questHudCtaShort,
 	questHudCtaFor,
@@ -297,15 +300,15 @@ describe('B2 — countCadenceSessionsInWindow', () => {
 
 describe('B2 — formatCadenceProgress', () => {
 	it('uses "this week" label for 7-day windows', () => {
-		expect(formatCadenceProgress(2, 3, 7)).toBe('2/3 this week');
+		expect(formatCadenceProgress(2, 3, 7)).toBe('2/3 sessions this week');
 	});
 
 	it('uses "in Nd" label for non-7-day windows', () => {
-		expect(formatCadenceProgress(1, 5, 14)).toBe('1/5 in 14d');
+		expect(formatCadenceProgress(1, 5, 14)).toBe('1/5 sessions in 14 days');
 	});
 
 	it('zero-completed state', () => {
-		expect(formatCadenceProgress(0, 3, 7)).toBe('0/3 this week');
+		expect(formatCadenceProgress(0, 3, 7)).toBe('0/3 sessions this week');
 	});
 });
 
@@ -439,5 +442,73 @@ describe('B4b — advisory parent-verified badge: bountyFromCoachIntent is unaff
 		expect(badgeSection).not.toMatch(/xpReward\s*=/);
 		expect(badgeSection).not.toMatch(/lifecycle\s*=/);
 		expect(badgeSection).not.toMatch(/sortKey\s*=/);
+	});
+});
+
+describe('cadence intelligence — per-day sessions', () => {
+	const coachQuest = (id: string): QuestTask => ({
+		id,
+		tier: 'bounty',
+		source: 'coach_intent',
+		senderLabel: 'Coach Challenge',
+		title: 'Pace · 200 XP goal',
+		axisId: 'PAC',
+		xpReward: 200,
+		lifecycle: 'complete',
+		actionHref: '/player/workout',
+		sortKey: 1,
+		targetAttributeId: 'pace',
+		cadence: { sessionsPerWindow: 5, windowDays: 14 },
+	});
+
+	it('countCadenceSessionsInWindow counts distinct UTC days only', () => {
+		const day1 = Date.parse('2026-06-10T12:00:00.000Z');
+		const day1b = Date.parse('2026-06-10T20:00:00.000Z');
+		const day2 = Date.parse('2026-06-11T09:00:00.000Z');
+		const now = Date.parse('2026-06-15T00:00:00.000Z');
+		const completions = [
+			{ attributeId: 'pace', loggedAtMs: day1 },
+			{ attributeId: 'pace', loggedAtMs: day1b },
+			{ attributeId: 'pace', loggedAtMs: day2 },
+		];
+		expect(countCadenceSessionsInWindow(completions, 'pace', 14, now)).toBe(2);
+	});
+
+	it('coachIntentSessionLoggedToday matches intentId for today', () => {
+		const todayMs = Date.now();
+		const quest = coachQuest('intent-1');
+		expect(
+			coachIntentSessionLoggedToday(
+				quest,
+				[{ attributeId: 'pace', loggedAtMs: todayMs, intentId: 'intent-1' }],
+				todayMs,
+			),
+		).toBe(true);
+		expect(questHudCtaFor(quest, { sessionLoggedToday: true })).toBe('Logged today');
+		expect(coachIntentCtaDisabled(quest, true)).toBe(true);
+	});
+
+	it('formatCadenceResumeHint after today session', () => {
+		expect(formatCadenceResumeHint(true, 1, 5)).toBe('Session logged — resume tomorrow');
+		expect(formatCadenceResumeHint(false, 1, 5)).toBeNull();
+		expect(formatCadenceResumeHint(true, 5, 5)).toBeNull();
+	});
+
+	it('bountyFromCoachIntent surfaces intentXpByUid for player', () => {
+		const bounty = bountyFromCoachIntent(
+			'intent-x',
+			{
+				targetAttributeId: 'pace',
+				requiredXp: 300,
+				intentXpByUid: { player1: 120 },
+			},
+			{ acceptedIds: [], completedIds: [], claimedIds: [], claimedDateUtc: '2026-01-01' },
+			'player1',
+		)!;
+		expect(bounty.intentXpEarned).toBe(120);
+	});
+
+	it('formatCadenceProgress uses session wording', () => {
+		expect(formatCadenceProgress(2, 5, 14)).toContain('2/5 sessions');
 	});
 });

--- a/src/lib/player/dashboard/activeBounties.ts
+++ b/src/lib/player/dashboard/activeBounties.ts
@@ -32,6 +32,8 @@ export type QuestTask = {
 	cadence?: { sessionsPerWindow: number; windowDays: number };
 	/** targetAttributeId from the intent — used to count completions per window. */
 	targetAttributeId?: string;
+	/** XP earned toward this coach intent (server intentXpByUid). */
+	intentXpEarned?: number;
 };
 
 export type QuestProgressStore = {
@@ -117,7 +119,17 @@ export function shouldDeferQuestCompletionUntilWorkoutLog(quest: QuestTask): boo
 }
 
 /** Lifecycle + route-aware CTA (Train-bound missions use Start session). */
-export function questHudCtaFor(quest: QuestTask): string {
+export function questHudCtaFor(
+	quest: QuestTask,
+	opts: { sessionLoggedToday?: boolean } = {},
+): string {
+	if (
+		opts.sessionLoggedToday &&
+		quest.source === 'coach_intent' &&
+		quest.lifecycle === 'complete'
+	) {
+		return 'Logged today';
+	}
 	if (
 		quest.lifecycle === 'complete' &&
 		quest.actionHref.includes('/player/workout') &&
@@ -128,6 +140,37 @@ export function questHudCtaFor(quest: QuestTask): string {
 		return 'Start session →';
 	}
 	return questHudCtaShort(quest.lifecycle);
+}
+
+/** Coach intent already logged today — grey out until next UTC day. */
+export function coachIntentSessionLoggedToday(
+	quest: QuestTask,
+	completions: ReadonlyArray<{ attributeId: string; loggedAtMs: number; intentId?: string }>,
+	now = Date.now(),
+): boolean {
+	if (quest.source !== 'coach_intent' || quest.lifecycle !== 'complete') return false;
+	const today = utcDateFromMs(now);
+	return completions.some((c) => {
+		if (utcDateFromMs(c.loggedAtMs) !== today) return false;
+		if (c.intentId && c.intentId === quest.id) return true;
+		return !c.intentId && quest.targetAttributeId === c.attributeId;
+	});
+}
+
+export function coachIntentCtaDisabled(quest: QuestTask, sessionLoggedToday: boolean): boolean {
+	return sessionLoggedToday && quest.source === 'coach_intent' && quest.lifecycle === 'complete';
+}
+
+export function coachIntentRailCta(
+	quest: QuestTask,
+	completions: ReadonlyArray<{ attributeId: string; loggedAtMs: number; intentId?: string }>,
+): { label: string; disabled: boolean; loggedToday: boolean } {
+	const loggedToday = coachIntentSessionLoggedToday(quest, completions);
+	return {
+		loggedToday,
+		disabled: coachIntentCtaDisabled(quest, loggedToday),
+		label: questHudCtaFor(quest, { sessionLoggedToday: loggedToday }),
+	};
 }
 
 /** Bracketed terminal command label for Player OS SIEM HUD. */
@@ -298,6 +341,10 @@ function emptyProgress(): QuestProgressStore {
 
 function utcDateString(): string {
 	return new Date().toISOString().slice(0, 10);
+}
+
+export function utcDateFromMs(ms: number): string {
+	return new Date(ms).toISOString().slice(0, 10);
 }
 
 export function mapAttributeToVanguardAxis(raw: string): VanguardAxisId {
@@ -475,9 +522,12 @@ export function countCadenceSessionsInWindow(
 	now = Date.now(),
 ): number {
 	const windowStart = now - windowDays * 86_400_000;
-	return completions.filter(
-		(c) => c.attributeId === attributeId && c.loggedAtMs >= windowStart,
-	).length;
+	const days = new Set<string>();
+	for (const c of completions) {
+		if (c.attributeId !== attributeId || c.loggedAtMs < windowStart) continue;
+		days.add(utcDateFromMs(c.loggedAtMs));
+	}
+	return days.size;
 }
 
 /**
@@ -489,8 +539,18 @@ export function formatCadenceProgress(
 	sessionsPerWindow: number,
 	windowDays: number,
 ): string {
-	const windowLabel = windowDays === 7 ? 'this week' : `in ${windowDays}d`;
-	return `${completed}/${sessionsPerWindow} ${windowLabel}`;
+	const windowLabel = windowDays === 7 ? 'this week' : `in ${windowDays} days`;
+	return `${completed}/${sessionsPerWindow} sessions ${windowLabel}`;
+}
+
+/** Hint after today's session when cadence goal not yet met. */
+export function formatCadenceResumeHint(
+	loggedToday: boolean,
+	completed: number,
+	sessionsPerWindow: number,
+): string | null {
+	if (!loggedToday || completed >= sessionsPerWindow) return null;
+	return 'Session logged — resume tomorrow';
 }
 
 export function bountyFromCoachIntent(
@@ -508,6 +568,14 @@ export function bountyFromCoachIntent(
 	const attrLabel = formatAttributeLabel(targetAttributeId);
 	const fulfilledBy = Array.isArray(data.fulfilledByUids) ? data.fulfilledByUids : [];
 	const playerFulfilled = Boolean(playerUid && fulfilledBy.includes(playerUid));
+	const intentXpMap =
+		data.intentXpByUid != null &&
+		typeof data.intentXpByUid === 'object' &&
+		!Array.isArray(data.intentXpByUid)
+			? (data.intentXpByUid as Record<string, number>)
+			: null;
+	const intentXpEarned =
+		playerUid && intentXpMap != null ? Math.max(0, Math.floor(Number(intentXpMap[playerUid]) || 0)) : undefined;
 	const rx = data.prescription;
 	const cadence =
 		rx != null &&
@@ -539,6 +607,7 @@ export function bountyFromCoachIntent(
 		actionHref: '/player/workout',
 		sortKey: priority,
 		targetAttributeId,
+		...(intentXpEarned != null ? { intentXpEarned } : {}),
 		...(cadence ? { cadence } : {}),
 	};
 }

--- a/src/lib/styles/active-bounties.css
+++ b/src/lib/styles/active-bounties.css
@@ -400,6 +400,29 @@
 	background: rgba(20, 184, 166, 0.06);
 }
 
+.quest-row__intent-xp {
+	margin: 0.15rem 0 0;
+	font-size: 0.55rem;
+	letter-spacing: 0.08em;
+	text-transform: uppercase;
+	color: rgba(148, 163, 184, 0.75);
+}
+
+.quest-row__intent-xp {
+	color: rgba(20, 184, 166, 0.65);
+}
+
+.player-hud-root .quest-row--rail.quest-row--embedded.quest-row--logged-today {
+	opacity: 0.72;
+}
+
+.player-hud-root .quest-row--rail.quest-row--embedded.quest-row--logged-today .quest-row__cmd--rail-chip:disabled {
+	opacity: 0.55;
+	cursor: not-allowed;
+	border-color: rgba(100, 116, 139, 0.35);
+	color: rgba(148, 163, 184, 0.85);
+}
+
 @media (max-width: 640px) {
 	.quest-row {
 		flex-wrap: wrap;

--- a/src/lib/types/intent.ts
+++ b/src/lib/types/intent.ts
@@ -163,6 +163,12 @@ export interface IntentDoc {
 
   /**
    * @since 1
+   * Per-player XP earned toward this intent (incremented on each log with intentId).
+   */
+  intentXpByUid?: Record<string, number>;
+
+  /**
+   * @since 1
    * Schema version stamp. Absent on pre-v1 documents; read-repair writes 1.
    */
   intentVersion: 1;

--- a/src/routes/(app)/player/dashboard/AdaptiveHomework.svelte
+++ b/src/routes/(app)/player/dashboard/AdaptiveHomework.svelte
@@ -9,12 +9,19 @@
 		doc,
 		getDoc,
 		setDoc,
+		Timestamp,
 	} from 'firebase/firestore';
 	import { browser } from '$app/environment';
 	import { goto } from '$app/navigation';
 	import { httpsCallable } from 'firebase/functions';
 	import { db, functions } from '$lib/firebase.js';
 	import { stashCoachIntentHandoffForAssignment, buildPolicyHintsFromResult } from '$lib/player/workout/coachMissionFlow.js';
+	import {
+		coachIntentSessionLoggedToday,
+		countCadenceSessionsInWindow,
+		formatCadenceProgress,
+		formatCadenceResumeHint,
+	} from '$lib/player/dashboard/activeBounties.js';
 	import { ensureRlPolicyCached, readRlPolicyCache } from '$lib/player/workout/rlPolicyCache.js';
 	import { authStore } from '$lib/stores/auth.svelte.js';
 	import { sportsConfigStore } from '$lib/stores/sportsConfigStore.svelte.js';
@@ -31,6 +38,7 @@
 		priority?: number;
 		status?: string;
 		prescription?: Record<string, unknown>;
+		intentXpByUid?: Record<string, number>;
 	}
 
 	interface Drill {
@@ -63,6 +71,7 @@
 	let assignments = $state<Assignment[]>([]);
 	let suggestedDrill = $state<Drill | null>(null);
 	let isLoading = $state(true);
+	let cadenceCompletions = $state<Array<{ attributeId: string; loggedAtMs: number; intentId?: string }>>([]);
 
 	// RL policy state
 	let policyResult = $state<PolicyResult | null>(null);
@@ -86,8 +95,58 @@
 
 	const playerAttributeXp = $derived.by(() => {
 		if (!activeAssignment || !playerProfile) return 0;
+		const uid = playerUid;
+		const intentMap = activeAssignment.intentXpByUid;
+		if (uid && intentMap && typeof intentMap === 'object') {
+			return Math.max(0, Math.floor(Number(intentMap[uid]) || 0));
+		}
 		const xpMap = /** @type {Record<string, number>} */ (playerProfile.xpByAttribute ?? {});
 		return Number(xpMap[activeAssignment.targetAttributeId] ?? 0);
+	});
+
+	const activeCadence = $derived.by(() => {
+		const rx = activeAssignment?.prescription;
+		if (!rx || typeof rx !== 'object' || Array.isArray(rx)) return undefined;
+		const c = (rx as Record<string, unknown>).cadence;
+		if (!c || typeof c !== 'object' || Array.isArray(c)) return undefined;
+		const spw = typeof (c as Record<string, unknown>).sessionsPerWindow === 'number'
+			? Math.floor((c as Record<string, unknown>).sessionsPerWindow as number)
+			: 0;
+		const wd = typeof (c as Record<string, unknown>).windowDays === 'number'
+			? Math.floor((c as Record<string, unknown>).windowDays as number)
+			: 0;
+		return spw >= 1 && spw <= 21 && wd >= 1 && wd <= 30
+			? { sessionsPerWindow: spw, windowDays: wd }
+			: undefined;
+	});
+
+	const cadenceCompleted = $derived.by(() => {
+		if (!activeAssignment || !activeCadence) return 0;
+		return countCadenceSessionsInWindow(
+			cadenceCompletions,
+			activeAssignment.targetAttributeId,
+			activeCadence.windowDays,
+		);
+	});
+
+	const homeworkLoggedToday = $derived.by(() => {
+		if (!activeAssignment) return false;
+		return coachIntentSessionLoggedToday(
+			{
+				id: activeAssignment.id,
+				tier: 'bounty',
+				source: 'coach_intent',
+				senderLabel: 'Coach Challenge',
+				title: '',
+				axisId: 'STM',
+				xpReward: activeAssignment.requiredXp,
+				lifecycle: 'complete',
+				actionHref: '/player/workout',
+				sortKey: 0,
+				targetAttributeId: activeAssignment.targetAttributeId,
+			},
+			cadenceCompletions,
+		);
 	});
 
 	const xpProgressPct = $derived.by(() => {
@@ -149,6 +208,44 @@
 			}
 		);
 
+		return unsub;
+	});
+
+	$effect(() => {
+		const uid = playerUid;
+		if (!uid || !activeAssignment) {
+			cadenceCompletions = [];
+			return;
+		}
+		const windowStart = Timestamp.fromMillis(Date.now() - 30 * 86_400_000);
+		const q = query(
+			collection(db, 'drill_completions'),
+			where('playerUid', '==', uid),
+			where('loggedAt', '>=', windowStart),
+		);
+		const unsub = onSnapshot(
+			q,
+			(snap) => {
+				cadenceCompletions = snap.docs.map((d) => {
+					const data = d.data();
+					const ts = data.loggedAt;
+					const ms =
+						ts instanceof Timestamp
+							? ts.toMillis()
+							: typeof ts?.toMillis === 'function'
+								? ts.toMillis()
+								: 0;
+					return {
+						attributeId: typeof data.attributeId === 'string' ? data.attributeId : '',
+						loggedAtMs: ms,
+						intentId: typeof data.intentId === 'string' ? data.intentId : undefined,
+					};
+				});
+			},
+			() => {
+				cadenceCompletions = [];
+			},
+		);
 		return unsub;
 	});
 
@@ -402,19 +499,38 @@
 
 			<button
 				type="button"
-				class="tw-w-full tw-py-2.5 tw-rounded-xl tw-font-mono tw-text-[10px] tw-tracking-widest
-				       tw-uppercase tw-border tw-border-teal-500/35 tw-text-teal-400 tw-bg-teal-500/10
-				       hover:tw-bg-teal-500/20 tw-transition-colors"
+				class="tw-w-full tw-py-2.5 tw-rounded-xl tw-font-mono tw-text-[10px] tw-tracking-widest tw-uppercase tw-border tw-transition-colors {homeworkLoggedToday
+					? 'tw-border-slate-600/50 tw-text-slate-500 tw-bg-slate-800/40'
+					: 'tw-border-teal-500/35 tw-text-teal-400 tw-bg-teal-500/10 hover:tw-bg-teal-500/20'}"
+				disabled={homeworkLoggedToday}
 				onclick={logOnTrain}
 			>
-				Log on Train
+				{homeworkLoggedToday ? 'Logged today — resume tomorrow' : 'Log on Train'}
 			</button>
 
-			<!-- XP progress bar -->
+			{#if activeCadence}
+				<p class="tw-font-mono tw-text-[9px] tw-tracking-widest tw-text-teal-400/70">
+					{formatCadenceProgress(
+						cadenceCompleted,
+						activeCadence.sessionsPerWindow,
+						activeCadence.windowDays,
+					)}
+				</p>
+				{@const resumeHint = formatCadenceResumeHint(
+					homeworkLoggedToday,
+					cadenceCompleted,
+					activeCadence.sessionsPerWindow,
+				)}
+				{#if resumeHint}
+					<p class="tw-font-mono tw-text-[9px] tw-text-white/35">{resumeHint}</p>
+				{/if}
+			{/if}
+
+			<!-- XP progress bar (mission-scoped when intentXpByUid present) -->
 			<div class="tw-flex tw-flex-col tw-gap-1.5">
 				<div class="tw-flex tw-justify-between tw-items-center">
 					<span class="tw-font-mono tw-text-[9px] tw-tracking-widest tw-text-white/30">
-						XP PROGRESS
+						MISSION XP
 					</span>
 					<span class="tw-font-mono tw-text-[9px] tw-text-teal-400/60">{xpProgressPct}%</span>
 				</div>

--- a/src/routes/(app)/player/workout/+page.svelte
+++ b/src/routes/(app)/player/workout/+page.svelte
@@ -608,7 +608,7 @@
         selectedDrill: drillName,
         activeMissionId: stepMissionId,
         missionSource: stepMissionSource,
-        targetAttributeId: armedHandoff?.targetAttributeId ?? undefined,
+        targetAttributeId: isLastStep ? (armedHandoff?.targetAttributeId ?? undefined) : undefined,
         totalXpHud,
         oldLevel,
         intensityStep: stepRpe,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Makes coach homework/cadence behave like a real multi-day assignment instead of allowing five sessions in one day.

### Server
- One cadence session per UTC day per attribute
- intentXpByUid tracks mission XP (not lifetime attribute total)
- Fulfillment requires intent XP and cadence when set

### Player UX
- Mission rail: mission XP, cadence progress, Logged today after session
- AdaptiveHomework mirrors cadence and logged-today state
- Bundle: one cadence tick on final step only

### Coach Forge
- Cadence windowDays follows assignment durationDays

## Test plan
- [x] Tests + build + deploy:core + hosting
- [ ] 5-in-14-day intent: log once greys out; same-day re-log does not advance cadence
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7ff6781-4b77-409c-95d4-ccc5049c3020"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7ff6781-4b77-409c-95d4-ccc5049c3020"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

