### PR TITLE
Fix parent dispatch code when JWT household lags Firestore

### DIFF
--- a/functions-commerce/src/middleware/authBouncers.js
+++ b/functions-commerce/src/middleware/authBouncers.js
@@ -184,6 +184,53 @@ function assertParent(request) {
 }
 
 /**
+ * Parent actor with householdId from Firestore users/{email} when present.
+ * JWT `householdId` can lag after waiver sign, household graph updates, or
+ * failed claim fast-paths — the household page reads Firestore, so callables
+ * must match.
+ * @param {any} request Callable request
+ * @return {Promise<{ email: string, householdId: string }>}
+ */
+async function assertParentAsync(request) {
+  if (!request.auth) {
+    throw new HttpsError('unauthenticated', 'Sign in required.');
+  }
+  if (request.auth.token.role !== 'parent') {
+    throw new HttpsError(
+        'permission-denied',
+        'Only parent accounts may use this action.',
+    );
+  }
+  const email = normEmail(request.auth.token.email);
+  if (!email) {
+    throw new HttpsError('invalid-argument', 'No email on session.');
+  }
+  const jwtHid =
+    typeof request.auth.token.householdId === 'string' ?
+      request.auth.token.householdId.trim() :
+      '';
+  let docHid = '';
+  try {
+    const pSnap = await db().collection('users').doc(email).get();
+    if (pSnap.exists) {
+      const raw = pSnap.data()?.householdId;
+      docHid = typeof raw === 'string' ? raw.trim() : '';
+    }
+  } catch {
+    /* fall through to JWT */
+  }
+  const householdId = docHid || jwtHid;
+  if (!householdId) {
+    throw new HttpsError(
+        'failed-precondition',
+        'Your account must be linked to a household. ' +
+        'Ask your director to connect parent and player emails.',
+    );
+  }
+  return {email, householdId};
+}
+
+/**
  * Assert caller is club staff for roster transfers.
  * @param {any} request Callable request
  * @return {Object} Actor with role, clubId, email
@@ -383,6 +430,7 @@ module.exports = {
   assertSuperAdmin,
   assertCanSecureAddPlayer,
   assertParent,
+  assertParentAsync,
   assertClubStaff,
   assertCoachMessageSender,
   assertActorCanAccessTeam,

--- a/functions-compliance/index.js
+++ b/functions-compliance/index.js
@@ -61,3 +61,4 @@ exports.parentLinkOperativeToTeam = operativeOps.parentLinkOperativeToTeam;
 exports.operativeSignInWithDispatch = operativeOps.operativeSignInWithDispatch;
 exports.generatePlayerOTP = operativeOps.generatePlayerOTP;
 exports.validatePlayerOTP = operativeOps.validatePlayerOTP;
+exports.parentReconcileHousehold = operativeOps.parentReconcileHousehold;

--- a/functions-compliance/src/domains/householdMembership.js
+++ b/functions-compliance/src/domains/householdMembership.js
@@ -1,0 +1,296 @@
+'use strict';
+
+/**
+ * Canonical household membership checks + safe graph repair.
+ *
+ * Admin surfaces may show linkage from denormalized `player_lookup.parentEmails`
+ * while parent callables gate on `households.playerEmails`. This module
+ * reconciles those views before rejecting parent actions.
+ */
+
+const admin = require('firebase-admin');
+const {HttpsError} = require('firebase-functions/v2/https');
+const logger = require('firebase-functions/logger');
+const {normEmail} = require('../utils/formatters');
+const {stampPlayerLookupGuardians} = require('./householdGraph');
+
+const db = () => admin.firestore();
+
+/**
+ * @param {unknown} raw
+ * @return {string[]}
+ */
+function emailList(raw) {
+  if (!Array.isArray(raw)) return [];
+  return [...new Set(raw.map((x) => normEmail(String(x))).filter(Boolean))];
+}
+
+/**
+ * @param {string} email
+ * @return {Promise<{ householdId: string, role: string, playerName: string }>}
+ */
+async function readUserHouseholdContext(email) {
+  const em = normEmail(email);
+  if (!em) {
+    return {householdId: '', role: '', playerName: ''};
+  }
+  const snap = await db().collection('users').doc(em).get();
+  if (!snap.exists) {
+    return {householdId: '', role: '', playerName: ''};
+  }
+  const d = snap.data() || {};
+  return {
+    householdId:
+      typeof d.householdId === 'string' ? d.householdId.trim() : '',
+    role: typeof d.role === 'string' ? d.role.trim() : '',
+    playerName:
+      typeof d.playerName === 'string' && d.playerName.trim() ?
+        d.playerName.trim() :
+        '',
+  };
+}
+
+/**
+ * @param {string} childEmail
+ * @return {Promise<{ householdId: string, parentEmails: string[] }>}
+ */
+async function readPlayerLookupGuardians(childEmail) {
+  const em = normEmail(childEmail);
+  if (!em) {
+    return {householdId: '', parentEmails: []};
+  }
+  const snap = await db().collection('player_lookup').doc(em).get();
+  if (!snap.exists) {
+    return {householdId: '', parentEmails: []};
+  }
+  const d = snap.data() || {};
+  return {
+    householdId:
+      typeof d.householdId === 'string' ? d.householdId.trim() : '',
+    parentEmails: emailList(d.parentEmails),
+  };
+}
+
+/**
+ * @param {string} householdId
+ * @param {string} parentEmail
+ * @param {string} childEmail
+ * @param {string} childName
+ * @return {Promise<boolean>}
+ */
+async function repairHouseholdMembership(
+    householdId,
+    parentEmail,
+    childEmail,
+    childName,
+) {
+  const hid = typeof householdId === 'string' ? householdId.trim() : '';
+  const parent = normEmail(parentEmail);
+  const child = normEmail(childEmail);
+  if (!hid || !parent || !child) {
+    return false;
+  }
+
+  const hRef = db().collection('households').doc(hid);
+  const hSnap = await hRef.get();
+  if (!hSnap.exists) {
+    return false;
+  }
+
+  const h = hSnap.data() || {};
+  const players = emailList(h.playerEmails);
+  const parents = emailList(h.parentEmails);
+  const names = Array.isArray(h.playerNames) ?
+    h.playerNames.filter((x) => typeof x === 'string' && x.trim()) :
+    [];
+
+  let changed = false;
+  if (!players.includes(child)) {
+    players.push(child);
+    changed = true;
+  }
+  if (!parents.includes(parent)) {
+    parents.push(parent);
+    changed = true;
+  }
+  if (childName && !names.includes(childName)) {
+    names.push(childName);
+    changed = true;
+  }
+
+  if (!changed) {
+    return true;
+  }
+
+  const now = admin.firestore.FieldValue.serverTimestamp();
+  const batch = db().batch();
+  batch.set(
+      hRef,
+      {
+        playerEmails: players,
+        parentEmails: parents,
+        playerNames: names,
+        updatedAt: now,
+      },
+      {merge: true},
+  );
+  batch.set(
+      db().collection('users').doc(parent),
+      {householdId: hid, updatedAt: now},
+      {merge: true},
+  );
+  batch.set(
+      db().collection('users').doc(child),
+      {householdId: hid, role: 'player', updatedAt: now},
+      {merge: true},
+  );
+  stampPlayerLookupGuardians(batch, child, {
+    householdId: hid,
+    parentEmails: parents,
+  });
+  batch.set(db().collection('security_audit').doc(), {
+    action: 'repairHouseholdMembership',
+    householdId: hid,
+    parentEmail: parent,
+    childEmail: child,
+    at: now,
+  });
+  await batch.commit();
+  logger.info('[repairHouseholdMembership] healed household graph', {
+    householdId: hid,
+    parentEmail: parent,
+    childEmail: child,
+  });
+  return true;
+}
+
+/**
+ * Resolve the household id that should gate a parent action.
+ * @param {{ email: string, householdId: string }} actor
+ * @return {Promise<string>}
+ */
+async function resolveParentHouseholdId(actor) {
+  const parentCtx = await readUserHouseholdContext(actor.email);
+  return parentCtx.householdId || actor.householdId || '';
+}
+
+/**
+ * Assert a child belongs to the parent's household, repairing denorm gaps when
+ * users + player_lookup agree but households.playerEmails is stale.
+ *
+ * @param {{ email: string, householdId: string }} actor
+ * @param {string} childUid
+ * @param {string} [requestedChildEmail] email sent by client (operative row)
+ */
+async function assertChildInParentHousehold(actor, childUid, requestedChildEmail) {
+  let childUser;
+  try {
+    childUser = await admin.auth().getUser(childUid);
+  } catch (e) {
+    if (e && e.code === 'auth/user-not-found') {
+      throw new HttpsError('not-found', 'Child account not found.');
+    }
+    throw e;
+  }
+
+  const authChildEm = normEmail(childUser.email);
+  const requestedEm = normEmail(requestedChildEmail);
+  const childEm = authChildEm || requestedEm;
+  if (!childEm) {
+    throw new HttpsError('failed-precondition', 'Child has no email on file.');
+  }
+  if (requestedEm && authChildEm && requestedEm !== authChildEm) {
+    throw new HttpsError(
+        'failed-precondition',
+        'Operative sign-in email does not match the provisioned account. ' +
+        'Contact your club to relink this athlete.',
+    );
+  }
+
+  const parentCtx = await readUserHouseholdContext(actor.email);
+  const childCtx = await readUserHouseholdContext(childEm);
+  const lookup = await readPlayerLookupGuardians(childEm);
+  const householdId =
+    parentCtx.householdId ||
+    actor.householdId ||
+    childCtx.householdId ||
+    lookup.householdId ||
+    '';
+
+  if (!householdId) {
+    throw new HttpsError(
+        'failed-precondition',
+        'Your account must be linked to a household. Sign the waiver on the household page first.',
+    );
+  }
+
+  const hSnap = await db().collection('households').doc(householdId).get();
+  if (!hSnap.exists) {
+    throw new HttpsError('not-found', 'Household not found.');
+  }
+
+  const h = hSnap.data() || {};
+  const players = emailList(h.playerEmails);
+  const parents = emailList(h.parentEmails);
+
+  const linkedOnHousehold =
+    players.includes(childEm) && parents.includes(actor.email);
+  const linkedOnUsers =
+    parentCtx.householdId &&
+    childCtx.householdId &&
+    parentCtx.householdId === childCtx.householdId;
+  const linkedOnLookup =
+    lookup.householdId === householdId &&
+    lookup.parentEmails.includes(actor.email);
+
+  if (!linkedOnHousehold && (linkedOnUsers || linkedOnLookup)) {
+    const repaired = await repairHouseholdMembership(
+        householdId,
+        actor.email,
+        childEm,
+        childCtx.playerName,
+    );
+    if (!repaired) {
+      throw new HttpsError(
+          'failed-precondition',
+          'Household linkage is inconsistent and could not be repaired automatically.',
+      );
+    }
+  } else if (!linkedOnHousehold) {
+    /** @type {string[]} */
+    const hints = [];
+    if (childCtx.householdId && childCtx.householdId !== householdId) {
+      hints.push(`player householdId=${childCtx.householdId}`);
+    }
+    if (lookup.parentEmails.length > 0 && !lookup.parentEmails.includes(actor.email)) {
+      hints.push('player_lookup lists a different guardian');
+    }
+    if (!players.includes(childEm)) {
+      hints.push('player missing from households.playerEmails');
+    }
+    if (!parents.includes(actor.email)) {
+      hints.push('parent missing from households.parentEmails');
+    }
+    const detail = hints.length > 0 ? ` (${hints.join('; ')})` : '';
+    throw new HttpsError(
+        'permission-denied',
+        'That player is not linked to your household.' + detail,
+    );
+  }
+
+  const uSnap = await db().collection('users').doc(childEm).get();
+  if (uSnap.exists) {
+    const r = uSnap.data().role;
+    if (r && r !== 'player') {
+      throw new HttpsError('failed-precondition', 'Target account is not a player.');
+    }
+  }
+}
+
+module.exports = {
+  assertChildInParentHousehold,
+  repairHouseholdMembership,
+  resolveParentHouseholdId,
+  readUserHouseholdContext,
+  readPlayerLookupGuardians,
+};

--- a/functions-compliance/src/domains/householdMembership.js
+++ b/functions-compliance/src/domains/householdMembership.js
@@ -287,9 +287,169 @@ async function assertChildInParentHousehold(actor, childUid, requestedChildEmail
   }
 }
 
+/**
+ * Discover linked players from player_lookup + users and heal canonical
+ * households.playerEmails so Parent OS matches admin-visible linkage.
+ * @param {string} parentEmail
+ * @return {Promise<{ householdId: string, playerEmails: string[], repaired: boolean }>}
+ */
+async function reconcileParentHouseholdGraph(parentEmail) {
+  const parent = normEmail(parentEmail);
+  if (!parent) {
+    return {householdId: '', playerEmails: [], repaired: false};
+  }
+
+  let hid = (await readUserHouseholdContext(parent)).householdId;
+
+  if (!hid) {
+    const byParentOnly = await db()
+        .collection('player_lookup')
+        .where('parentEmails', 'array-contains', parent)
+        .limit(12)
+        .get();
+    const hidSet = new Set();
+    for (const row of byParentOnly.docs) {
+      const plHid =
+        typeof row.data().householdId === 'string' ?
+          row.data().householdId.trim() :
+          '';
+      if (plHid) hidSet.add(plHid);
+    }
+    if (hidSet.size === 1) {
+      hid = [...hidSet][0];
+    } else {
+      return {householdId: '', playerEmails: [], repaired: false};
+    }
+  }
+
+  const hRef = db().collection('households').doc(hid);
+  const hSnap = await hRef.get();
+  if (!hSnap.exists) {
+    return {householdId: hid, playerEmails: [], repaired: false};
+  }
+
+  const h = hSnap.data() || {};
+  const existingPlayers = emailList(h.playerEmails);
+  const existingParents = emailList(h.parentEmails);
+  const discovered = new Set(existingPlayers);
+
+  const byHid = await db()
+      .collection('player_lookup')
+      .where('householdId', '==', hid)
+      .get();
+  for (const row of byHid.docs) {
+    const em = normEmail(row.id);
+    const parents = emailList(row.data().parentEmails);
+    if (em && (parents.length === 0 || parents.includes(parent))) {
+      discovered.add(em);
+    }
+  }
+
+  const byParent = await db()
+      .collection('player_lookup')
+      .where('parentEmails', 'array-contains', parent)
+      .get();
+  for (const row of byParent.docs) {
+    const em = normEmail(row.id);
+    const plHid =
+      typeof row.data().householdId === 'string' ?
+        row.data().householdId.trim() :
+        '';
+    if (em && (!plHid || plHid === hid)) {
+      discovered.add(em);
+    }
+  }
+
+  /** @type {string[]} */
+  const verified = [];
+  for (const childEm of discovered) {
+    const childCtx = await readUserHouseholdContext(childEm);
+    const lookup = await readPlayerLookupGuardians(childEm);
+    const linkedViaUsers = childCtx.householdId === hid;
+    const linkedViaLookup =
+      lookup.parentEmails.includes(parent) &&
+      (!lookup.householdId || lookup.householdId === hid);
+    if (linkedViaUsers || linkedViaLookup || existingPlayers.includes(childEm)) {
+      verified.push(childEm);
+    }
+  }
+
+  const mergedPlayers = [...new Set([...existingPlayers, ...verified])];
+  const mergedParents = existingParents.includes(parent) ?
+    existingParents :
+    [...existingParents, parent];
+  const nameSet = new Set(
+      Array.isArray(h.playerNames) ?
+        h.playerNames.filter((x) => typeof x === 'string' && x.trim()) :
+        [],
+  );
+
+  for (const childEm of mergedPlayers) {
+    if (!nameSet.size || [...nameSet].length < mergedPlayers.length) {
+      const childCtx = await readUserHouseholdContext(childEm);
+      if (childCtx.playerName) {
+        nameSet.add(childCtx.playerName);
+      }
+    }
+  }
+
+  const needsHouseholdRepair =
+    mergedPlayers.length !== existingPlayers.length ||
+    mergedParents.length !== existingParents.length;
+  const parentNeedsHid = (await readUserHouseholdContext(parent)).householdId !== hid;
+
+  if (!needsHouseholdRepair && !parentNeedsHid) {
+    return {householdId: hid, playerEmails: mergedPlayers, repaired: false};
+  }
+
+  const now = admin.firestore.FieldValue.serverTimestamp();
+  const batch = db().batch();
+  batch.set(
+      hRef,
+      {
+        playerEmails: mergedPlayers,
+        parentEmails: mergedParents,
+        playerNames: [...nameSet],
+        updatedAt: now,
+      },
+      {merge: true},
+  );
+  batch.set(
+      db().collection('users').doc(parent),
+      {householdId: hid, updatedAt: now},
+      {merge: true},
+  );
+  for (const childEm of mergedPlayers) {
+    batch.set(
+        db().collection('users').doc(childEm),
+        {householdId: hid, role: 'player', updatedAt: now},
+        {merge: true},
+    );
+    stampPlayerLookupGuardians(batch, childEm, {
+      householdId: hid,
+      parentEmails: mergedParents,
+    });
+  }
+  batch.set(db().collection('security_audit').doc(), {
+    action: 'reconcileParentHouseholdGraph',
+    householdId: hid,
+    parentEmail: parent,
+    playerEmails: mergedPlayers,
+    at: now,
+  });
+  await batch.commit();
+  logger.info('[reconcileParentHouseholdGraph] healed household roster', {
+    householdId: hid,
+    parentEmail: parent,
+    playerCount: mergedPlayers.length,
+  });
+  return {householdId: hid, playerEmails: mergedPlayers, repaired: true};
+}
+
 module.exports = {
   assertChildInParentHousehold,
   repairHouseholdMembership,
+  reconcileParentHouseholdGraph,
   resolveParentHouseholdId,
   readUserHouseholdContext,
   readPlayerLookupGuardians,

--- a/functions-compliance/src/domains/operativeOps.js
+++ b/functions-compliance/src/domains/operativeOps.js
@@ -11,6 +11,7 @@ const {normEmail, normOperativeCallsignSlug, computeAgeYears} =
 const {
   assertSuperAdmin,
   assertParent,
+  assertParentAsync,
   assertCoachMessageSender,
 } = require('../middleware/authBouncers');
 const {
@@ -717,7 +718,7 @@ async function assertHouseholdThreadActor(request) {
   }
 
   if (role === 'parent') {
-    const actor = assertParent(request);
+    const actor = await assertParentAsync(request);
     return {email: actor.email, householdId: actor.householdId, role: 'parent'};
   }
 
@@ -1724,7 +1725,7 @@ exports.generatePlayerOTP = onCall({region: REGION}, async (request) => {
         'childUid or childEmail is required.',
     );
   }
-  const actor = assertParent(request);
+  const actor = await assertParentAsync(request);
   await assertChildInParentHousehold(actor, childUid);
   const parentUid = request.auth.uid;
   const nowMs = Date.now();

--- a/functions-compliance/src/domains/operativeOps.js
+++ b/functions-compliance/src/domains/operativeOps.js
@@ -23,7 +23,8 @@ const {
 const {sendFcmToUids} = require('./notificationOps');
 const {provisionLoungesForParentHousehold} = require('./commsChannelOps');
 const {buildBaseCustomClaims} = require('../auth/customClaims');
-const {assertChildInParentHousehold} = require('./householdMembership');
+const {assertChildInParentHousehold, reconcileParentHouseholdGraph} =
+  require('./householdMembership');
 
 const REGION = 'us-east1';
 
@@ -1698,6 +1699,21 @@ exports.generatePlayerOTP = onCall({region: REGION}, async (request) => {
     return {code, expiresAt: expiresAt.toDate().toISOString()};
   }
   throw new HttpsError('unavailable', 'Could not issue a unique code. Try again.');
+});
+
+/**
+ * Parent: sync households.playerEmails from player_lookup/users denorm so
+ * Household Clearance shows the same athletes admin already lists.
+ */
+exports.parentReconcileHousehold = onCall({region: REGION}, async (request) => {
+  const actor = await assertParentAsync(request);
+  const result = await reconcileParentHouseholdGraph(actor.email);
+  return {
+    ok: true,
+    householdId: result.householdId,
+    playerEmails: result.playerEmails,
+    repaired: result.repaired,
+  };
 });
 
 /**

--- a/functions-compliance/src/domains/operativeOps.js
+++ b/functions-compliance/src/domains/operativeOps.js
@@ -23,6 +23,7 @@ const {
 const {sendFcmToUids} = require('./notificationOps');
 const {provisionLoungesForParentHousehold} = require('./commsChannelOps');
 const {buildBaseCustomClaims} = require('../auth/customClaims');
+const {assertChildInParentHousehold} = require('./householdMembership');
 
 const REGION = 'us-east1';
 
@@ -254,56 +255,6 @@ async function resolveUserUidFromUsernameOrCallsign(raw) {
   const em = q.docs[0].id;
   const rec = await admin.auth().getUserByEmail(em);
   return rec.uid;
-}
-
-/**
- * @param {{ email: string, householdId: string }} actor
- * @param {string} childUid
- */
-async function assertChildInParentHousehold(actor, childUid) {
-  let childUser;
-  try {
-    childUser = await admin.auth().getUser(childUid);
-  } catch (e) {
-    if (e && e.code === 'auth/user-not-found') {
-      throw new HttpsError('not-found', 'Child account not found.');
-    }
-    throw e;
-  }
-  const childEm = normEmail(childUser.email);
-  if (!childEm) {
-    throw new HttpsError('failed-precondition', 'Child has no email on file.');
-  }
-  const hSnap = await db().collection('households').doc(actor.householdId).get();
-  if (!hSnap.exists) {
-    throw new HttpsError('not-found', 'Household not found.');
-  }
-  const h = hSnap.data();
-  const players = (h.playerEmails || [])
-      .map((x) => normEmail(String(x)))
-      .filter(Boolean);
-  if (!players.includes(childEm)) {
-    throw new HttpsError(
-        'permission-denied',
-        'That player is not linked to your household.',
-    );
-  }
-  const parents = (h.parentEmails || [])
-      .map((x) => normEmail(String(x)))
-      .filter(Boolean);
-  if (!parents.includes(actor.email)) {
-    throw new HttpsError(
-        'permission-denied',
-        'You are not an authorized parent on this household.',
-    );
-  }
-  const uSnap = await db().collection('users').doc(childEm).get();
-  if (uSnap.exists) {
-    const r = uSnap.data().role;
-    if (r && r !== 'player') {
-      throw new HttpsError('failed-precondition', 'Target account is not a player.');
-    }
-  }
 }
 
 // ── Exported callable functions ──────────────────────────────────────────────
@@ -1726,7 +1677,7 @@ exports.generatePlayerOTP = onCall({region: REGION}, async (request) => {
     );
   }
   const actor = await assertParentAsync(request);
-  await assertChildInParentHousehold(actor, childUid);
+  await assertChildInParentHousehold(actor, childUid, childEm);
   const parentUid = request.auth.uid;
   const nowMs = Date.now();
   const tenMin = 10 * 60 * 1000;

--- a/functions-compliance/src/middleware/authBouncers.js
+++ b/functions-compliance/src/middleware/authBouncers.js
@@ -184,6 +184,53 @@ function assertParent(request) {
 }
 
 /**
+ * Parent actor with householdId from Firestore users/{email} when present.
+ * JWT `householdId` can lag after waiver sign, household graph updates, or
+ * failed claim fast-paths — the household page reads Firestore, so callables
+ * must match.
+ * @param {any} request Callable request
+ * @return {Promise<{ email: string, householdId: string }>}
+ */
+async function assertParentAsync(request) {
+  if (!request.auth) {
+    throw new HttpsError('unauthenticated', 'Sign in required.');
+  }
+  if (request.auth.token.role !== 'parent') {
+    throw new HttpsError(
+        'permission-denied',
+        'Only parent accounts may use this action.',
+    );
+  }
+  const email = normEmail(request.auth.token.email);
+  if (!email) {
+    throw new HttpsError('invalid-argument', 'No email on session.');
+  }
+  const jwtHid =
+    typeof request.auth.token.householdId === 'string' ?
+      request.auth.token.householdId.trim() :
+      '';
+  let docHid = '';
+  try {
+    const pSnap = await db().collection('users').doc(email).get();
+    if (pSnap.exists) {
+      const raw = pSnap.data()?.householdId;
+      docHid = typeof raw === 'string' ? raw.trim() : '';
+    }
+  } catch {
+    /* fall through to JWT */
+  }
+  const householdId = docHid || jwtHid;
+  if (!householdId) {
+    throw new HttpsError(
+        'failed-precondition',
+        'Your account must be linked to a household. ' +
+        'Ask your director to connect parent and player emails.',
+    );
+  }
+  return {email, householdId};
+}
+
+/**
  * Assert caller is club staff for roster transfers.
  * @param {any} request Callable request
  * @return {Object} Actor with role, clubId, email
@@ -383,6 +430,7 @@ module.exports = {
   assertSuperAdmin,
   assertCanSecureAddPlayer,
   assertParent,
+  assertParentAsync,
   assertClubStaff,
   assertCoachMessageSender,
   assertActorCanAccessTeam,

--- a/functions-platform/src/domains/householdMembership.js
+++ b/functions-platform/src/domains/householdMembership.js
@@ -1,0 +1,296 @@
+'use strict';
+
+/**
+ * Canonical household membership checks + safe graph repair.
+ *
+ * Admin surfaces may show linkage from denormalized `player_lookup.parentEmails`
+ * while parent callables gate on `households.playerEmails`. This module
+ * reconciles those views before rejecting parent actions.
+ */
+
+const admin = require('firebase-admin');
+const {HttpsError} = require('firebase-functions/v2/https');
+const logger = require('firebase-functions/logger');
+const {normEmail} = require('../utils/formatters');
+const {stampPlayerLookupGuardians} = require('./householdGraph');
+
+const db = () => admin.firestore();
+
+/**
+ * @param {unknown} raw
+ * @return {string[]}
+ */
+function emailList(raw) {
+  if (!Array.isArray(raw)) return [];
+  return [...new Set(raw.map((x) => normEmail(String(x))).filter(Boolean))];
+}
+
+/**
+ * @param {string} email
+ * @return {Promise<{ householdId: string, role: string, playerName: string }>}
+ */
+async function readUserHouseholdContext(email) {
+  const em = normEmail(email);
+  if (!em) {
+    return {householdId: '', role: '', playerName: ''};
+  }
+  const snap = await db().collection('users').doc(em).get();
+  if (!snap.exists) {
+    return {householdId: '', role: '', playerName: ''};
+  }
+  const d = snap.data() || {};
+  return {
+    householdId:
+      typeof d.householdId === 'string' ? d.householdId.trim() : '',
+    role: typeof d.role === 'string' ? d.role.trim() : '',
+    playerName:
+      typeof d.playerName === 'string' && d.playerName.trim() ?
+        d.playerName.trim() :
+        '',
+  };
+}
+
+/**
+ * @param {string} childEmail
+ * @return {Promise<{ householdId: string, parentEmails: string[] }>}
+ */
+async function readPlayerLookupGuardians(childEmail) {
+  const em = normEmail(childEmail);
+  if (!em) {
+    return {householdId: '', parentEmails: []};
+  }
+  const snap = await db().collection('player_lookup').doc(em).get();
+  if (!snap.exists) {
+    return {householdId: '', parentEmails: []};
+  }
+  const d = snap.data() || {};
+  return {
+    householdId:
+      typeof d.householdId === 'string' ? d.householdId.trim() : '',
+    parentEmails: emailList(d.parentEmails),
+  };
+}
+
+/**
+ * @param {string} householdId
+ * @param {string} parentEmail
+ * @param {string} childEmail
+ * @param {string} childName
+ * @return {Promise<boolean>}
+ */
+async function repairHouseholdMembership(
+    householdId,
+    parentEmail,
+    childEmail,
+    childName,
+) {
+  const hid = typeof householdId === 'string' ? householdId.trim() : '';
+  const parent = normEmail(parentEmail);
+  const child = normEmail(childEmail);
+  if (!hid || !parent || !child) {
+    return false;
+  }
+
+  const hRef = db().collection('households').doc(hid);
+  const hSnap = await hRef.get();
+  if (!hSnap.exists) {
+    return false;
+  }
+
+  const h = hSnap.data() || {};
+  const players = emailList(h.playerEmails);
+  const parents = emailList(h.parentEmails);
+  const names = Array.isArray(h.playerNames) ?
+    h.playerNames.filter((x) => typeof x === 'string' && x.trim()) :
+    [];
+
+  let changed = false;
+  if (!players.includes(child)) {
+    players.push(child);
+    changed = true;
+  }
+  if (!parents.includes(parent)) {
+    parents.push(parent);
+    changed = true;
+  }
+  if (childName && !names.includes(childName)) {
+    names.push(childName);
+    changed = true;
+  }
+
+  if (!changed) {
+    return true;
+  }
+
+  const now = admin.firestore.FieldValue.serverTimestamp();
+  const batch = db().batch();
+  batch.set(
+      hRef,
+      {
+        playerEmails: players,
+        parentEmails: parents,
+        playerNames: names,
+        updatedAt: now,
+      },
+      {merge: true},
+  );
+  batch.set(
+      db().collection('users').doc(parent),
+      {householdId: hid, updatedAt: now},
+      {merge: true},
+  );
+  batch.set(
+      db().collection('users').doc(child),
+      {householdId: hid, role: 'player', updatedAt: now},
+      {merge: true},
+  );
+  stampPlayerLookupGuardians(batch, child, {
+    householdId: hid,
+    parentEmails: parents,
+  });
+  batch.set(db().collection('security_audit').doc(), {
+    action: 'repairHouseholdMembership',
+    householdId: hid,
+    parentEmail: parent,
+    childEmail: child,
+    at: now,
+  });
+  await batch.commit();
+  logger.info('[repairHouseholdMembership] healed household graph', {
+    householdId: hid,
+    parentEmail: parent,
+    childEmail: child,
+  });
+  return true;
+}
+
+/**
+ * Resolve the household id that should gate a parent action.
+ * @param {{ email: string, householdId: string }} actor
+ * @return {Promise<string>}
+ */
+async function resolveParentHouseholdId(actor) {
+  const parentCtx = await readUserHouseholdContext(actor.email);
+  return parentCtx.householdId || actor.householdId || '';
+}
+
+/**
+ * Assert a child belongs to the parent's household, repairing denorm gaps when
+ * users + player_lookup agree but households.playerEmails is stale.
+ *
+ * @param {{ email: string, householdId: string }} actor
+ * @param {string} childUid
+ * @param {string} [requestedChildEmail] email sent by client (operative row)
+ */
+async function assertChildInParentHousehold(actor, childUid, requestedChildEmail) {
+  let childUser;
+  try {
+    childUser = await admin.auth().getUser(childUid);
+  } catch (e) {
+    if (e && e.code === 'auth/user-not-found') {
+      throw new HttpsError('not-found', 'Child account not found.');
+    }
+    throw e;
+  }
+
+  const authChildEm = normEmail(childUser.email);
+  const requestedEm = normEmail(requestedChildEmail);
+  const childEm = authChildEm || requestedEm;
+  if (!childEm) {
+    throw new HttpsError('failed-precondition', 'Child has no email on file.');
+  }
+  if (requestedEm && authChildEm && requestedEm !== authChildEm) {
+    throw new HttpsError(
+        'failed-precondition',
+        'Operative sign-in email does not match the provisioned account. ' +
+        'Contact your club to relink this athlete.',
+    );
+  }
+
+  const parentCtx = await readUserHouseholdContext(actor.email);
+  const childCtx = await readUserHouseholdContext(childEm);
+  const lookup = await readPlayerLookupGuardians(childEm);
+  const householdId =
+    parentCtx.householdId ||
+    actor.householdId ||
+    childCtx.householdId ||
+    lookup.householdId ||
+    '';
+
+  if (!householdId) {
+    throw new HttpsError(
+        'failed-precondition',
+        'Your account must be linked to a household. Sign the waiver on the household page first.',
+    );
+  }
+
+  const hSnap = await db().collection('households').doc(householdId).get();
+  if (!hSnap.exists) {
+    throw new HttpsError('not-found', 'Household not found.');
+  }
+
+  const h = hSnap.data() || {};
+  const players = emailList(h.playerEmails);
+  const parents = emailList(h.parentEmails);
+
+  const linkedOnHousehold =
+    players.includes(childEm) && parents.includes(actor.email);
+  const linkedOnUsers =
+    parentCtx.householdId &&
+    childCtx.householdId &&
+    parentCtx.householdId === childCtx.householdId;
+  const linkedOnLookup =
+    lookup.householdId === householdId &&
+    lookup.parentEmails.includes(actor.email);
+
+  if (!linkedOnHousehold && (linkedOnUsers || linkedOnLookup)) {
+    const repaired = await repairHouseholdMembership(
+        householdId,
+        actor.email,
+        childEm,
+        childCtx.playerName,
+    );
+    if (!repaired) {
+      throw new HttpsError(
+          'failed-precondition',
+          'Household linkage is inconsistent and could not be repaired automatically.',
+      );
+    }
+  } else if (!linkedOnHousehold) {
+    /** @type {string[]} */
+    const hints = [];
+    if (childCtx.householdId && childCtx.householdId !== householdId) {
+      hints.push(`player householdId=${childCtx.householdId}`);
+    }
+    if (lookup.parentEmails.length > 0 && !lookup.parentEmails.includes(actor.email)) {
+      hints.push('player_lookup lists a different guardian');
+    }
+    if (!players.includes(childEm)) {
+      hints.push('player missing from households.playerEmails');
+    }
+    if (!parents.includes(actor.email)) {
+      hints.push('parent missing from households.parentEmails');
+    }
+    const detail = hints.length > 0 ? ` (${hints.join('; ')})` : '';
+    throw new HttpsError(
+        'permission-denied',
+        'That player is not linked to your household.' + detail,
+    );
+  }
+
+  const uSnap = await db().collection('users').doc(childEm).get();
+  if (uSnap.exists) {
+    const r = uSnap.data().role;
+    if (r && r !== 'player') {
+      throw new HttpsError('failed-precondition', 'Target account is not a player.');
+    }
+  }
+}
+
+module.exports = {
+  assertChildInParentHousehold,
+  repairHouseholdMembership,
+  resolveParentHouseholdId,
+  readUserHouseholdContext,
+  readPlayerLookupGuardians,
+};

--- a/functions-platform/src/domains/operativeOps.js
+++ b/functions-platform/src/domains/operativeOps.js
@@ -11,6 +11,7 @@ const {normEmail, normOperativeCallsignSlug, computeAgeYears} =
 const {
   assertSuperAdmin,
   assertParent,
+  assertParentAsync,
   assertCoachMessageSender,
 } = require('../middleware/authBouncers');
 const {
@@ -717,7 +718,7 @@ async function assertHouseholdThreadActor(request) {
   }
 
   if (role === 'parent') {
-    const actor = assertParent(request);
+    const actor = await assertParentAsync(request);
     return {email: actor.email, householdId: actor.householdId, role: 'parent'};
   }
 
@@ -1724,7 +1725,7 @@ exports.generatePlayerOTP = onCall({region: REGION}, async (request) => {
         'childUid or childEmail is required.',
     );
   }
-  const actor = assertParent(request);
+  const actor = await assertParentAsync(request);
   await assertChildInParentHousehold(actor, childUid);
   const parentUid = request.auth.uid;
   const nowMs = Date.now();

--- a/functions-platform/src/domains/operativeOps.js
+++ b/functions-platform/src/domains/operativeOps.js
@@ -23,6 +23,7 @@ const {
 const {sendFcmToUids} = require('./notificationOps');
 const {provisionLoungesForParentHousehold} = require('./commsChannelOps');
 const {buildBaseCustomClaims} = require('../auth/customClaims');
+const {assertChildInParentHousehold} = require('./householdMembership');
 
 const REGION = 'us-east1';
 
@@ -254,56 +255,6 @@ async function resolveUserUidFromUsernameOrCallsign(raw) {
   const em = q.docs[0].id;
   const rec = await admin.auth().getUserByEmail(em);
   return rec.uid;
-}
-
-/**
- * @param {{ email: string, householdId: string }} actor
- * @param {string} childUid
- */
-async function assertChildInParentHousehold(actor, childUid) {
-  let childUser;
-  try {
-    childUser = await admin.auth().getUser(childUid);
-  } catch (e) {
-    if (e && e.code === 'auth/user-not-found') {
-      throw new HttpsError('not-found', 'Child account not found.');
-    }
-    throw e;
-  }
-  const childEm = normEmail(childUser.email);
-  if (!childEm) {
-    throw new HttpsError('failed-precondition', 'Child has no email on file.');
-  }
-  const hSnap = await db().collection('households').doc(actor.householdId).get();
-  if (!hSnap.exists) {
-    throw new HttpsError('not-found', 'Household not found.');
-  }
-  const h = hSnap.data();
-  const players = (h.playerEmails || [])
-      .map((x) => normEmail(String(x)))
-      .filter(Boolean);
-  if (!players.includes(childEm)) {
-    throw new HttpsError(
-        'permission-denied',
-        'That player is not linked to your household.',
-    );
-  }
-  const parents = (h.parentEmails || [])
-      .map((x) => normEmail(String(x)))
-      .filter(Boolean);
-  if (!parents.includes(actor.email)) {
-    throw new HttpsError(
-        'permission-denied',
-        'You are not an authorized parent on this household.',
-    );
-  }
-  const uSnap = await db().collection('users').doc(childEm).get();
-  if (uSnap.exists) {
-    const r = uSnap.data().role;
-    if (r && r !== 'player') {
-      throw new HttpsError('failed-precondition', 'Target account is not a player.');
-    }
-  }
 }
 
 // ── Exported callable functions ──────────────────────────────────────────────
@@ -1726,7 +1677,7 @@ exports.generatePlayerOTP = onCall({region: REGION}, async (request) => {
     );
   }
   const actor = await assertParentAsync(request);
-  await assertChildInParentHousehold(actor, childUid);
+  await assertChildInParentHousehold(actor, childUid, childEm);
   const parentUid = request.auth.uid;
   const nowMs = Date.now();
   const tenMin = 10 * 60 * 1000;

--- a/functions-platform/src/middleware/authBouncers.js
+++ b/functions-platform/src/middleware/authBouncers.js
@@ -184,6 +184,53 @@ function assertParent(request) {
 }
 
 /**
+ * Parent actor with householdId from Firestore users/{email} when present.
+ * JWT `householdId` can lag after waiver sign, household graph updates, or
+ * failed claim fast-paths — the household page reads Firestore, so callables
+ * must match.
+ * @param {any} request Callable request
+ * @return {Promise<{ email: string, householdId: string }>}
+ */
+async function assertParentAsync(request) {
+  if (!request.auth) {
+    throw new HttpsError('unauthenticated', 'Sign in required.');
+  }
+  if (request.auth.token.role !== 'parent') {
+    throw new HttpsError(
+        'permission-denied',
+        'Only parent accounts may use this action.',
+    );
+  }
+  const email = normEmail(request.auth.token.email);
+  if (!email) {
+    throw new HttpsError('invalid-argument', 'No email on session.');
+  }
+  const jwtHid =
+    typeof request.auth.token.householdId === 'string' ?
+      request.auth.token.householdId.trim() :
+      '';
+  let docHid = '';
+  try {
+    const pSnap = await db().collection('users').doc(email).get();
+    if (pSnap.exists) {
+      const raw = pSnap.data()?.householdId;
+      docHid = typeof raw === 'string' ? raw.trim() : '';
+    }
+  } catch {
+    /* fall through to JWT */
+  }
+  const householdId = docHid || jwtHid;
+  if (!householdId) {
+    throw new HttpsError(
+        'failed-precondition',
+        'Your account must be linked to a household. ' +
+        'Ask your director to connect parent and player emails.',
+    );
+  }
+  return {email, householdId};
+}
+
+/**
  * Assert caller is club staff for roster transfers.
  * @param {any} request Callable request
  * @return {Object} Actor with role, clubId, email
@@ -383,6 +430,7 @@ module.exports = {
   assertSuperAdmin,
   assertCanSecureAddPlayer,
   assertParent,
+  assertParentAsync,
   assertClubStaff,
   assertCoachMessageSender,
   assertActorCanAccessTeam,

--- a/functions/__tests__/functionsDeploy.guard.test.js
+++ b/functions/__tests__/functionsDeploy.guard.test.js
@@ -159,6 +159,7 @@ describe('functionsDeploy guard — codebase indexes', () => {
       'operativeSignInWithDispatch',
       'generatePlayerOTP',
       'validatePlayerOTP',
+      'parentReconcileHousehold',
     ]) {
       assertExportLine(name, src);
     }

--- a/functions/src/domains/__tests__/householdMembership.test.js
+++ b/functions/src/domains/__tests__/householdMembership.test.js
@@ -1,0 +1,214 @@
+'use strict';
+
+/**
+ * householdMembership.test.js
+ * Run: node functions/src/domains/__tests__/householdMembership.test.js
+ */
+
+const assert = require('assert');
+const {HttpsError} = require('firebase-functions/v2/https');
+
+const STORES = {
+  users: new Map(),
+  households: new Map(),
+  player_lookup: new Map(),
+  security_audit: new Map(),
+};
+
+const authUsers = new Map();
+
+function resetStores() {
+  STORES.users.clear();
+  STORES.households.clear();
+  STORES.player_lookup.clear();
+  STORES.security_audit.clear();
+  authUsers.clear();
+}
+
+function setUser(email, data) {
+  STORES.users.set(email, {...data});
+}
+
+function setHousehold(id, data) {
+  STORES.households.set(id, {...data});
+}
+
+function setLookup(email, data) {
+  STORES.player_lookup.set(email, {...data});
+}
+
+const admin = require('firebase-admin');
+if (!admin.apps.length) {
+  admin.initializeApp({projectId: 'test-project'});
+}
+
+const firestore = admin.firestore();
+const originalCollection = firestore.collection.bind(firestore);
+
+function makeDocRef(collectionName, id) {
+  return {
+    id,
+    _collection: collectionName,
+    get: async () => {
+      const data = STORES[collectionName].get(id);
+      return {exists: Boolean(data), data: () => data, id};
+    },
+    set: async (payload, opts) => {
+      const prev = STORES[collectionName].get(id) || {};
+      STORES[collectionName].set(
+          id,
+          opts && opts.merge ? {...prev, ...payload} : {...payload},
+      );
+    },
+  };
+}
+
+firestore.collection = (name) => {
+  if (!Object.prototype.hasOwnProperty.call(STORES, name)) {
+    return originalCollection(name);
+  }
+  return {
+    doc: (id) => makeDocRef(name, id),
+    add: async (payload) => {
+      const id = `audit-${STORES.security_audit.size + 1}`;
+      STORES.security_audit.set(id, payload);
+      return {id};
+    },
+  };
+};
+
+firestore.batch = () => {
+  /** @type {Array<{ ref: { _collection: string, id: string }, payload: Record<string, unknown>, merge?: boolean }>} */
+  const ops = [];
+  return {
+    set: (ref, payload, opts) => {
+      ops.push({ref, payload, merge: opts && opts.merge});
+    },
+    commit: async () => {
+      for (const op of ops) {
+        const prev = STORES[op.ref._collection].get(op.ref.id) || {};
+        STORES[op.ref._collection].set(
+            op.ref.id,
+            op.merge ? {...prev, ...op.payload} : {...op.payload},
+        );
+      }
+    },
+  };
+};
+
+Object.defineProperty(admin, 'auth', {
+  configurable: true,
+  value: () => ({
+    getUser: async (uid) => {
+      const row = authUsers.get(uid);
+      if (!row) {
+        const err = new Error('not found');
+        err.code = 'auth/user-not-found';
+        throw err;
+      }
+      return row;
+    },
+  }),
+});
+
+delete require.cache[require.resolve('../householdMembership')];
+const membership = require('../householdMembership');
+
+let passed = 0;
+let failed = 0;
+
+async function test(name, fn) {
+  try {
+    resetStores();
+    await fn();
+    console.log(`  ✓  ${name}`);
+    passed++;
+  } catch (err) {
+    console.error(`  ✗  ${name}`);
+    console.error(`       ${err.message}`);
+    failed++;
+  }
+}
+
+console.log('\nhouseholdMembership — graph reconciliation\n');
+
+(async () => {
+  await test('repairs when users + lookup agree but households.playerEmails is stale', async () => {
+    const parent = 'parent@example.com';
+    const child = 'slug@operative.local';
+    const hid = 'hh-1';
+
+    setUser(parent, {role: 'parent', householdId: hid});
+    setUser(child, {role: 'player', householdId: hid, playerName: 'Slug'});
+    setHousehold(hid, {
+      clubId: 'club-1',
+      parentEmails: [parent],
+      playerEmails: [],
+      playerNames: [],
+    });
+    setLookup(child, {householdId: hid, parentEmails: [parent]});
+    authUsers.set('child-uid', {uid: 'child-uid', email: child});
+
+    await membership.assertChildInParentHousehold(
+        {email: parent, householdId: hid},
+        'child-uid',
+        child,
+    );
+
+    const healed = STORES.households.get(hid);
+    assert.ok(healed.playerEmails.includes(child));
+    assert.ok(healed.parentEmails.includes(parent));
+  });
+
+  await test('rejects when neither household nor lookup links parent to child', async () => {
+    const parent = 'parent@example.com';
+    const child = 'slug@operative.local';
+    const hid = 'hh-1';
+
+    setUser(parent, {role: 'parent', householdId: hid});
+    setUser(child, {role: 'player', householdId: 'other-hh'});
+    setHousehold(hid, {
+      parentEmails: [parent],
+      playerEmails: [],
+    });
+    setLookup(child, {householdId: 'other-hh', parentEmails: ['other@example.com']});
+    authUsers.set('child-uid', {uid: 'child-uid', email: child});
+
+    let err;
+    try {
+      await membership.assertChildInParentHousehold(
+          {email: parent, householdId: hid},
+          'child-uid',
+          child,
+      );
+    } catch (e) {
+      err = e;
+    }
+    assert.ok(err instanceof HttpsError);
+    assert.strictEqual(err.code, 'permission-denied');
+    assert.match(err.message, /not linked to your household/i);
+  });
+
+  await test('passes when household graph is already canonical', async () => {
+    const parent = 'parent@example.com';
+    const child = 'slug@operative.local';
+    const hid = 'hh-1';
+
+    setUser(parent, {role: 'parent', householdId: hid});
+    setUser(child, {role: 'player', householdId: hid});
+    setHousehold(hid, {
+      parentEmails: [parent],
+      playerEmails: [child],
+    });
+    authUsers.set('child-uid', {uid: 'child-uid', email: child});
+
+    await membership.assertChildInParentHousehold(
+        {email: parent, householdId: hid},
+        'child-uid',
+        child,
+    );
+  });
+
+  console.log(`\n${passed} passed, ${failed} failed\n`);
+  process.exit(failed > 0 ? 1 : 0);
+})();

--- a/functions/src/domains/householdMembership.js
+++ b/functions/src/domains/householdMembership.js
@@ -1,0 +1,296 @@
+'use strict';
+
+/**
+ * Canonical household membership checks + safe graph repair.
+ *
+ * Admin surfaces may show linkage from denormalized `player_lookup.parentEmails`
+ * while parent callables gate on `households.playerEmails`. This module
+ * reconciles those views before rejecting parent actions.
+ */
+
+const admin = require('firebase-admin');
+const {HttpsError} = require('firebase-functions/v2/https');
+const logger = require('firebase-functions/logger');
+const {normEmail} = require('../utils/formatters');
+const {stampPlayerLookupGuardians} = require('./householdGraph');
+
+const db = () => admin.firestore();
+
+/**
+ * @param {unknown} raw
+ * @return {string[]}
+ */
+function emailList(raw) {
+  if (!Array.isArray(raw)) return [];
+  return [...new Set(raw.map((x) => normEmail(String(x))).filter(Boolean))];
+}
+
+/**
+ * @param {string} email
+ * @return {Promise<{ householdId: string, role: string, playerName: string }>}
+ */
+async function readUserHouseholdContext(email) {
+  const em = normEmail(email);
+  if (!em) {
+    return {householdId: '', role: '', playerName: ''};
+  }
+  const snap = await db().collection('users').doc(em).get();
+  if (!snap.exists) {
+    return {householdId: '', role: '', playerName: ''};
+  }
+  const d = snap.data() || {};
+  return {
+    householdId:
+      typeof d.householdId === 'string' ? d.householdId.trim() : '',
+    role: typeof d.role === 'string' ? d.role.trim() : '',
+    playerName:
+      typeof d.playerName === 'string' && d.playerName.trim() ?
+        d.playerName.trim() :
+        '',
+  };
+}
+
+/**
+ * @param {string} childEmail
+ * @return {Promise<{ householdId: string, parentEmails: string[] }>}
+ */
+async function readPlayerLookupGuardians(childEmail) {
+  const em = normEmail(childEmail);
+  if (!em) {
+    return {householdId: '', parentEmails: []};
+  }
+  const snap = await db().collection('player_lookup').doc(em).get();
+  if (!snap.exists) {
+    return {householdId: '', parentEmails: []};
+  }
+  const d = snap.data() || {};
+  return {
+    householdId:
+      typeof d.householdId === 'string' ? d.householdId.trim() : '',
+    parentEmails: emailList(d.parentEmails),
+  };
+}
+
+/**
+ * @param {string} householdId
+ * @param {string} parentEmail
+ * @param {string} childEmail
+ * @param {string} childName
+ * @return {Promise<boolean>}
+ */
+async function repairHouseholdMembership(
+    householdId,
+    parentEmail,
+    childEmail,
+    childName,
+) {
+  const hid = typeof householdId === 'string' ? householdId.trim() : '';
+  const parent = normEmail(parentEmail);
+  const child = normEmail(childEmail);
+  if (!hid || !parent || !child) {
+    return false;
+  }
+
+  const hRef = db().collection('households').doc(hid);
+  const hSnap = await hRef.get();
+  if (!hSnap.exists) {
+    return false;
+  }
+
+  const h = hSnap.data() || {};
+  const players = emailList(h.playerEmails);
+  const parents = emailList(h.parentEmails);
+  const names = Array.isArray(h.playerNames) ?
+    h.playerNames.filter((x) => typeof x === 'string' && x.trim()) :
+    [];
+
+  let changed = false;
+  if (!players.includes(child)) {
+    players.push(child);
+    changed = true;
+  }
+  if (!parents.includes(parent)) {
+    parents.push(parent);
+    changed = true;
+  }
+  if (childName && !names.includes(childName)) {
+    names.push(childName);
+    changed = true;
+  }
+
+  if (!changed) {
+    return true;
+  }
+
+  const now = admin.firestore.FieldValue.serverTimestamp();
+  const batch = db().batch();
+  batch.set(
+      hRef,
+      {
+        playerEmails: players,
+        parentEmails: parents,
+        playerNames: names,
+        updatedAt: now,
+      },
+      {merge: true},
+  );
+  batch.set(
+      db().collection('users').doc(parent),
+      {householdId: hid, updatedAt: now},
+      {merge: true},
+  );
+  batch.set(
+      db().collection('users').doc(child),
+      {householdId: hid, role: 'player', updatedAt: now},
+      {merge: true},
+  );
+  stampPlayerLookupGuardians(batch, child, {
+    householdId: hid,
+    parentEmails: parents,
+  });
+  batch.set(db().collection('security_audit').doc(), {
+    action: 'repairHouseholdMembership',
+    householdId: hid,
+    parentEmail: parent,
+    childEmail: child,
+    at: now,
+  });
+  await batch.commit();
+  logger.info('[repairHouseholdMembership] healed household graph', {
+    householdId: hid,
+    parentEmail: parent,
+    childEmail: child,
+  });
+  return true;
+}
+
+/**
+ * Resolve the household id that should gate a parent action.
+ * @param {{ email: string, householdId: string }} actor
+ * @return {Promise<string>}
+ */
+async function resolveParentHouseholdId(actor) {
+  const parentCtx = await readUserHouseholdContext(actor.email);
+  return parentCtx.householdId || actor.householdId || '';
+}
+
+/**
+ * Assert a child belongs to the parent's household, repairing denorm gaps when
+ * users + player_lookup agree but households.playerEmails is stale.
+ *
+ * @param {{ email: string, householdId: string }} actor
+ * @param {string} childUid
+ * @param {string} [requestedChildEmail] email sent by client (operative row)
+ */
+async function assertChildInParentHousehold(actor, childUid, requestedChildEmail) {
+  let childUser;
+  try {
+    childUser = await admin.auth().getUser(childUid);
+  } catch (e) {
+    if (e && e.code === 'auth/user-not-found') {
+      throw new HttpsError('not-found', 'Child account not found.');
+    }
+    throw e;
+  }
+
+  const authChildEm = normEmail(childUser.email);
+  const requestedEm = normEmail(requestedChildEmail);
+  const childEm = authChildEm || requestedEm;
+  if (!childEm) {
+    throw new HttpsError('failed-precondition', 'Child has no email on file.');
+  }
+  if (requestedEm && authChildEm && requestedEm !== authChildEm) {
+    throw new HttpsError(
+        'failed-precondition',
+        'Operative sign-in email does not match the provisioned account. ' +
+        'Contact your club to relink this athlete.',
+    );
+  }
+
+  const parentCtx = await readUserHouseholdContext(actor.email);
+  const childCtx = await readUserHouseholdContext(childEm);
+  const lookup = await readPlayerLookupGuardians(childEm);
+  const householdId =
+    parentCtx.householdId ||
+    actor.householdId ||
+    childCtx.householdId ||
+    lookup.householdId ||
+    '';
+
+  if (!householdId) {
+    throw new HttpsError(
+        'failed-precondition',
+        'Your account must be linked to a household. Sign the waiver on the household page first.',
+    );
+  }
+
+  const hSnap = await db().collection('households').doc(householdId).get();
+  if (!hSnap.exists) {
+    throw new HttpsError('not-found', 'Household not found.');
+  }
+
+  const h = hSnap.data() || {};
+  const players = emailList(h.playerEmails);
+  const parents = emailList(h.parentEmails);
+
+  const linkedOnHousehold =
+    players.includes(childEm) && parents.includes(actor.email);
+  const linkedOnUsers =
+    parentCtx.householdId &&
+    childCtx.householdId &&
+    parentCtx.householdId === childCtx.householdId;
+  const linkedOnLookup =
+    lookup.householdId === householdId &&
+    lookup.parentEmails.includes(actor.email);
+
+  if (!linkedOnHousehold && (linkedOnUsers || linkedOnLookup)) {
+    const repaired = await repairHouseholdMembership(
+        householdId,
+        actor.email,
+        childEm,
+        childCtx.playerName,
+    );
+    if (!repaired) {
+      throw new HttpsError(
+          'failed-precondition',
+          'Household linkage is inconsistent and could not be repaired automatically.',
+      );
+    }
+  } else if (!linkedOnHousehold) {
+    /** @type {string[]} */
+    const hints = [];
+    if (childCtx.householdId && childCtx.householdId !== householdId) {
+      hints.push(`player householdId=${childCtx.householdId}`);
+    }
+    if (lookup.parentEmails.length > 0 && !lookup.parentEmails.includes(actor.email)) {
+      hints.push('player_lookup lists a different guardian');
+    }
+    if (!players.includes(childEm)) {
+      hints.push('player missing from households.playerEmails');
+    }
+    if (!parents.includes(actor.email)) {
+      hints.push('parent missing from households.parentEmails');
+    }
+    const detail = hints.length > 0 ? ` (${hints.join('; ')})` : '';
+    throw new HttpsError(
+        'permission-denied',
+        'That player is not linked to your household.' + detail,
+    );
+  }
+
+  const uSnap = await db().collection('users').doc(childEm).get();
+  if (uSnap.exists) {
+    const r = uSnap.data().role;
+    if (r && r !== 'player') {
+      throw new HttpsError('failed-precondition', 'Target account is not a player.');
+    }
+  }
+}
+
+module.exports = {
+  assertChildInParentHousehold,
+  repairHouseholdMembership,
+  resolveParentHouseholdId,
+  readUserHouseholdContext,
+  readPlayerLookupGuardians,
+};

--- a/functions/src/domains/householdMembership.js
+++ b/functions/src/domains/householdMembership.js
@@ -287,9 +287,169 @@ async function assertChildInParentHousehold(actor, childUid, requestedChildEmail
   }
 }
 
+/**
+ * Discover linked players from player_lookup + users and heal canonical
+ * households.playerEmails so Parent OS matches admin-visible linkage.
+ * @param {string} parentEmail
+ * @return {Promise<{ householdId: string, playerEmails: string[], repaired: boolean }>}
+ */
+async function reconcileParentHouseholdGraph(parentEmail) {
+  const parent = normEmail(parentEmail);
+  if (!parent) {
+    return {householdId: '', playerEmails: [], repaired: false};
+  }
+
+  let hid = (await readUserHouseholdContext(parent)).householdId;
+
+  if (!hid) {
+    const byParentOnly = await db()
+        .collection('player_lookup')
+        .where('parentEmails', 'array-contains', parent)
+        .limit(12)
+        .get();
+    const hidSet = new Set();
+    for (const row of byParentOnly.docs) {
+      const plHid =
+        typeof row.data().householdId === 'string' ?
+          row.data().householdId.trim() :
+          '';
+      if (plHid) hidSet.add(plHid);
+    }
+    if (hidSet.size === 1) {
+      hid = [...hidSet][0];
+    } else {
+      return {householdId: '', playerEmails: [], repaired: false};
+    }
+  }
+
+  const hRef = db().collection('households').doc(hid);
+  const hSnap = await hRef.get();
+  if (!hSnap.exists) {
+    return {householdId: hid, playerEmails: [], repaired: false};
+  }
+
+  const h = hSnap.data() || {};
+  const existingPlayers = emailList(h.playerEmails);
+  const existingParents = emailList(h.parentEmails);
+  const discovered = new Set(existingPlayers);
+
+  const byHid = await db()
+      .collection('player_lookup')
+      .where('householdId', '==', hid)
+      .get();
+  for (const row of byHid.docs) {
+    const em = normEmail(row.id);
+    const parents = emailList(row.data().parentEmails);
+    if (em && (parents.length === 0 || parents.includes(parent))) {
+      discovered.add(em);
+    }
+  }
+
+  const byParent = await db()
+      .collection('player_lookup')
+      .where('parentEmails', 'array-contains', parent)
+      .get();
+  for (const row of byParent.docs) {
+    const em = normEmail(row.id);
+    const plHid =
+      typeof row.data().householdId === 'string' ?
+        row.data().householdId.trim() :
+        '';
+    if (em && (!plHid || plHid === hid)) {
+      discovered.add(em);
+    }
+  }
+
+  /** @type {string[]} */
+  const verified = [];
+  for (const childEm of discovered) {
+    const childCtx = await readUserHouseholdContext(childEm);
+    const lookup = await readPlayerLookupGuardians(childEm);
+    const linkedViaUsers = childCtx.householdId === hid;
+    const linkedViaLookup =
+      lookup.parentEmails.includes(parent) &&
+      (!lookup.householdId || lookup.householdId === hid);
+    if (linkedViaUsers || linkedViaLookup || existingPlayers.includes(childEm)) {
+      verified.push(childEm);
+    }
+  }
+
+  const mergedPlayers = [...new Set([...existingPlayers, ...verified])];
+  const mergedParents = existingParents.includes(parent) ?
+    existingParents :
+    [...existingParents, parent];
+  const nameSet = new Set(
+      Array.isArray(h.playerNames) ?
+        h.playerNames.filter((x) => typeof x === 'string' && x.trim()) :
+        [],
+  );
+
+  for (const childEm of mergedPlayers) {
+    if (!nameSet.size || [...nameSet].length < mergedPlayers.length) {
+      const childCtx = await readUserHouseholdContext(childEm);
+      if (childCtx.playerName) {
+        nameSet.add(childCtx.playerName);
+      }
+    }
+  }
+
+  const needsHouseholdRepair =
+    mergedPlayers.length !== existingPlayers.length ||
+    mergedParents.length !== existingParents.length;
+  const parentNeedsHid = (await readUserHouseholdContext(parent)).householdId !== hid;
+
+  if (!needsHouseholdRepair && !parentNeedsHid) {
+    return {householdId: hid, playerEmails: mergedPlayers, repaired: false};
+  }
+
+  const now = admin.firestore.FieldValue.serverTimestamp();
+  const batch = db().batch();
+  batch.set(
+      hRef,
+      {
+        playerEmails: mergedPlayers,
+        parentEmails: mergedParents,
+        playerNames: [...nameSet],
+        updatedAt: now,
+      },
+      {merge: true},
+  );
+  batch.set(
+      db().collection('users').doc(parent),
+      {householdId: hid, updatedAt: now},
+      {merge: true},
+  );
+  for (const childEm of mergedPlayers) {
+    batch.set(
+        db().collection('users').doc(childEm),
+        {householdId: hid, role: 'player', updatedAt: now},
+        {merge: true},
+    );
+    stampPlayerLookupGuardians(batch, childEm, {
+      householdId: hid,
+      parentEmails: mergedParents,
+    });
+  }
+  batch.set(db().collection('security_audit').doc(), {
+    action: 'reconcileParentHouseholdGraph',
+    householdId: hid,
+    parentEmail: parent,
+    playerEmails: mergedPlayers,
+    at: now,
+  });
+  await batch.commit();
+  logger.info('[reconcileParentHouseholdGraph] healed household roster', {
+    householdId: hid,
+    parentEmail: parent,
+    playerCount: mergedPlayers.length,
+  });
+  return {householdId: hid, playerEmails: mergedPlayers, repaired: true};
+}
+
 module.exports = {
   assertChildInParentHousehold,
   repairHouseholdMembership,
+  reconcileParentHouseholdGraph,
   resolveParentHouseholdId,
   readUserHouseholdContext,
   readPlayerLookupGuardians,

--- a/functions/src/domains/operativeOps.js
+++ b/functions/src/domains/operativeOps.js
@@ -11,6 +11,7 @@ const {normEmail, normOperativeCallsignSlug, computeAgeYears} =
 const {
   assertSuperAdmin,
   assertParent,
+  assertParentAsync,
   assertCoachMessageSender,
 } = require('../middleware/authBouncers');
 const {
@@ -717,7 +718,7 @@ async function assertHouseholdThreadActor(request) {
   }
 
   if (role === 'parent') {
-    const actor = assertParent(request);
+    const actor = await assertParentAsync(request);
     return {email: actor.email, householdId: actor.householdId, role: 'parent'};
   }
 
@@ -1724,7 +1725,7 @@ exports.generatePlayerOTP = onCall({region: REGION}, async (request) => {
         'childUid or childEmail is required.',
     );
   }
-  const actor = assertParent(request);
+  const actor = await assertParentAsync(request);
   await assertChildInParentHousehold(actor, childUid);
   const parentUid = request.auth.uid;
   const nowMs = Date.now();

--- a/functions/src/domains/operativeOps.js
+++ b/functions/src/domains/operativeOps.js
@@ -23,7 +23,8 @@ const {
 const {sendFcmToUids} = require('./notificationOps');
 const {provisionLoungesForParentHousehold} = require('./commsChannelOps');
 const {buildBaseCustomClaims} = require('../auth/customClaims');
-const {assertChildInParentHousehold} = require('./householdMembership');
+const {assertChildInParentHousehold, reconcileParentHouseholdGraph} =
+  require('./householdMembership');
 
 const REGION = 'us-east1';
 
@@ -1698,6 +1699,21 @@ exports.generatePlayerOTP = onCall({region: REGION}, async (request) => {
     return {code, expiresAt: expiresAt.toDate().toISOString()};
   }
   throw new HttpsError('unavailable', 'Could not issue a unique code. Try again.');
+});
+
+/**
+ * Parent: sync households.playerEmails from player_lookup/users denorm so
+ * Household Clearance shows the same athletes admin already lists.
+ */
+exports.parentReconcileHousehold = onCall({region: REGION}, async (request) => {
+  const actor = await assertParentAsync(request);
+  const result = await reconcileParentHouseholdGraph(actor.email);
+  return {
+    ok: true,
+    householdId: result.householdId,
+    playerEmails: result.playerEmails,
+    repaired: result.repaired,
+  };
 });
 
 /**

--- a/functions/src/domains/operativeOps.js
+++ b/functions/src/domains/operativeOps.js
@@ -23,6 +23,7 @@ const {
 const {sendFcmToUids} = require('./notificationOps');
 const {provisionLoungesForParentHousehold} = require('./commsChannelOps');
 const {buildBaseCustomClaims} = require('../auth/customClaims');
+const {assertChildInParentHousehold} = require('./householdMembership');
 
 const REGION = 'us-east1';
 
@@ -254,56 +255,6 @@ async function resolveUserUidFromUsernameOrCallsign(raw) {
   const em = q.docs[0].id;
   const rec = await admin.auth().getUserByEmail(em);
   return rec.uid;
-}
-
-/**
- * @param {{ email: string, householdId: string }} actor
- * @param {string} childUid
- */
-async function assertChildInParentHousehold(actor, childUid) {
-  let childUser;
-  try {
-    childUser = await admin.auth().getUser(childUid);
-  } catch (e) {
-    if (e && e.code === 'auth/user-not-found') {
-      throw new HttpsError('not-found', 'Child account not found.');
-    }
-    throw e;
-  }
-  const childEm = normEmail(childUser.email);
-  if (!childEm) {
-    throw new HttpsError('failed-precondition', 'Child has no email on file.');
-  }
-  const hSnap = await db().collection('households').doc(actor.householdId).get();
-  if (!hSnap.exists) {
-    throw new HttpsError('not-found', 'Household not found.');
-  }
-  const h = hSnap.data();
-  const players = (h.playerEmails || [])
-      .map((x) => normEmail(String(x)))
-      .filter(Boolean);
-  if (!players.includes(childEm)) {
-    throw new HttpsError(
-        'permission-denied',
-        'That player is not linked to your household.',
-    );
-  }
-  const parents = (h.parentEmails || [])
-      .map((x) => normEmail(String(x)))
-      .filter(Boolean);
-  if (!parents.includes(actor.email)) {
-    throw new HttpsError(
-        'permission-denied',
-        'You are not an authorized parent on this household.',
-    );
-  }
-  const uSnap = await db().collection('users').doc(childEm).get();
-  if (uSnap.exists) {
-    const r = uSnap.data().role;
-    if (r && r !== 'player') {
-      throw new HttpsError('failed-precondition', 'Target account is not a player.');
-    }
-  }
 }
 
 // ── Exported callable functions ──────────────────────────────────────────────
@@ -1726,7 +1677,7 @@ exports.generatePlayerOTP = onCall({region: REGION}, async (request) => {
     );
   }
   const actor = await assertParentAsync(request);
-  await assertChildInParentHousehold(actor, childUid);
+  await assertChildInParentHousehold(actor, childUid, childEm);
   const parentUid = request.auth.uid;
   const nowMs = Date.now();
   const tenMin = 10 * 60 * 1000;

--- a/functions/src/middleware/__tests__/authBouncers.test.js
+++ b/functions/src/middleware/__tests__/authBouncers.test.js
@@ -1,0 +1,106 @@
+'use strict';
+
+/**
+ * authBouncers.test.js — parent householdId resolution (Firestore vs JWT)
+ * Run: node functions/src/middleware/__tests__/authBouncers.test.js
+ */
+
+const assert = require('assert');
+
+const mockGet = async (email) => {
+  const docs = {
+    'parent@example.com': {householdId: 'hh-firestore'},
+  };
+  const data = docs[email];
+  return {
+    exists: Boolean(data),
+    data: () => data,
+  };
+};
+
+const admin = require('firebase-admin');
+if (!admin.apps.length) {
+  admin.initializeApp({projectId: 'test-project'});
+}
+
+const firestore = admin.firestore();
+const originalCollection = firestore.collection.bind(firestore);
+firestore.collection = (name) => {
+  const col = originalCollection(name);
+  if (name !== 'users') {
+    return col;
+  }
+  return {
+    doc: (email) => ({
+      get: () => mockGet(email),
+    }),
+  };
+};
+
+const {assertParentAsync} = require('../authBouncers');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  return (async () => {
+    try {
+      await fn();
+      console.log(`  ✓  ${name}`);
+      passed++;
+    } catch (err) {
+      console.error(`  ✗  ${name}`);
+      console.error(`       ${err.message}`);
+      failed++;
+    }
+  })();
+}
+
+console.log('\nauthBouncers — assertParentAsync household resolution\n');
+
+(async () => {
+  await test('prefers Firestore householdId over stale JWT claim', async () => {
+    const actor = await assertParentAsync({
+      auth: {
+        uid: 'uid-parent',
+        token: {
+          role: 'parent',
+          email: 'parent@example.com',
+          householdId: 'hh-stale-jwt',
+        },
+      },
+    });
+    assert.strictEqual(actor.email, 'parent@example.com');
+    assert.strictEqual(actor.householdId, 'hh-firestore');
+  });
+
+  await test('falls back to JWT householdId when Firestore doc is missing', async () => {
+    const actor = await assertParentAsync({
+      auth: {
+        uid: 'uid-parent2',
+        token: {
+          role: 'parent',
+          email: 'jwt-only@example.com',
+          householdId: 'hh-jwt-only',
+        },
+      },
+    });
+    assert.strictEqual(actor.householdId, 'hh-jwt-only');
+  });
+
+  await test('rejects non-parent role', async () => {
+    let err;
+    try {
+      await assertParentAsync({
+        auth: {token: {role: 'coach', email: 'coach@example.com', householdId: 'hh-1'}},
+      });
+    } catch (e) {
+      err = e;
+    }
+    assert.ok(err);
+    assert.strictEqual(err.code, 'permission-denied');
+  });
+
+  console.log(`\n${passed} passed, ${failed} failed\n`);
+  process.exit(failed > 0 ? 1 : 0);
+})();

--- a/functions/src/middleware/authBouncers.js
+++ b/functions/src/middleware/authBouncers.js
@@ -184,6 +184,53 @@ function assertParent(request) {
 }
 
 /**
+ * Parent actor with householdId from Firestore users/{email} when present.
+ * JWT `householdId` can lag after waiver sign, household graph updates, or
+ * failed claim fast-paths — the household page reads Firestore, so callables
+ * must match.
+ * @param {any} request Callable request
+ * @return {Promise<{ email: string, householdId: string }>}
+ */
+async function assertParentAsync(request) {
+  if (!request.auth) {
+    throw new HttpsError('unauthenticated', 'Sign in required.');
+  }
+  if (request.auth.token.role !== 'parent') {
+    throw new HttpsError(
+        'permission-denied',
+        'Only parent accounts may use this action.',
+    );
+  }
+  const email = normEmail(request.auth.token.email);
+  if (!email) {
+    throw new HttpsError('invalid-argument', 'No email on session.');
+  }
+  const jwtHid =
+    typeof request.auth.token.householdId === 'string' ?
+      request.auth.token.householdId.trim() :
+      '';
+  let docHid = '';
+  try {
+    const pSnap = await db().collection('users').doc(email).get();
+    if (pSnap.exists) {
+      const raw = pSnap.data()?.householdId;
+      docHid = typeof raw === 'string' ? raw.trim() : '';
+    }
+  } catch {
+    /* fall through to JWT */
+  }
+  const householdId = docHid || jwtHid;
+  if (!householdId) {
+    throw new HttpsError(
+        'failed-precondition',
+        'Your account must be linked to a household. ' +
+        'Ask your director to connect parent and player emails.',
+    );
+  }
+  return {email, householdId};
+}
+
+/**
  * Assert caller is club staff for roster transfers.
  * @param {any} request Callable request
  * @return {Object} Actor with role, clubId, email
@@ -383,6 +430,7 @@ module.exports = {
   assertSuperAdmin,
   assertCanSecureAddPlayer,
   assertParent,
+  assertParentAsync,
   assertClubStaff,
   assertCoachMessageSender,
   assertActorCanAccessTeam,

--- a/scripts/audit-household-graph.mjs
+++ b/scripts/audit-household-graph.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+/**
+ * Read-only audit: find household graph disconnects between admin-visible
+ * linkage (player_lookup + users.householdId) and callable gates
+ * (households.playerEmails / parentEmails).
+ *
+ * Usage:
+ *   GOOGLE_APPLICATION_CREDENTIALS=... node scripts/audit-household-graph.mjs
+ *   node scripts/audit-household-graph.mjs --project sports-skill-tracker-dev
+ */
+
+import admin from 'firebase-admin';
+
+const projectId =
+  process.argv.includes('--project') ?
+    process.argv[process.argv.indexOf('--project') + 1] :
+    process.env.GCLOUD_PROJECT || process.env.GCP_PROJECT || 'sports-skill-tracker-dev';
+
+if (!admin.apps.length) {
+  admin.initializeApp({projectId});
+}
+
+const db = admin.firestore();
+
+function normEmail(v) {
+  return typeof v === 'string' ? v.trim().toLowerCase() : '';
+}
+
+function emailList(raw) {
+  if (!Array.isArray(raw)) return [];
+  return [...new Set(raw.map((x) => normEmail(String(x))).filter(Boolean))];
+}
+
+/** @type {Array<Record<string, unknown>>} */
+const issues = [];
+
+async function main() {
+  console.log(`[audit-household-graph] project=${projectId}\n`);
+
+  const households = await db.collection('households').get();
+  const lookupSnap = await db.collection('player_lookup').get();
+
+  for (const hdoc of households.docs) {
+    const hid = hdoc.id;
+    const h = hdoc.data() || {};
+    const players = emailList(h.playerEmails);
+    const parents = emailList(h.parentEmails);
+
+    for (const pem of players) {
+      const u = await db.collection('users').doc(pem).get();
+      const uhid =
+        u.exists && typeof u.data().householdId === 'string' ?
+          u.data().householdId.trim() :
+          '';
+      if (uhid && uhid !== hid) {
+        issues.push({
+          kind: 'player_users_household_mismatch',
+          householdId: hid,
+          playerEmail: pem,
+          userHouseholdId: uhid,
+        });
+      }
+    }
+
+    for (const par of parents) {
+      const u = await db.collection('users').doc(par).get();
+      const uhid =
+        u.exists && typeof u.data().householdId === 'string' ?
+          u.data().householdId.trim() :
+          '';
+      if (uhid && uhid !== hid) {
+        issues.push({
+          kind: 'parent_users_household_mismatch',
+          householdId: hid,
+          parentEmail: par,
+          userHouseholdId: uhid,
+        });
+      }
+    }
+  }
+
+  for (const ldoc of lookupSnap.docs) {
+    const pem = ldoc.id;
+    const l = ldoc.data() || {};
+    const plHid = typeof l.householdId === 'string' ? l.householdId.trim() : '';
+    const plParents = emailList(l.parentEmails);
+    if (!plHid || plParents.length === 0) continue;
+
+    const hs = await db.collection('households').doc(plHid).get();
+    if (!hs.exists) {
+      issues.push({
+        kind: 'lookup_household_missing',
+        playerEmail: pem,
+        lookupHouseholdId: plHid,
+        lookupParents: plParents,
+      });
+      continue;
+    }
+
+    const pe = emailList(hs.data().playerEmails);
+    const hp = emailList(hs.data().parentEmails);
+
+    if (!pe.includes(pem)) {
+      issues.push({
+        kind: 'admin_visible_but_not_in_household_players',
+        playerEmail: pem,
+        householdId: plHid,
+        lookupParents: plParents,
+        fix: 'repairHouseholdMembership or director linkHousehold',
+      });
+    }
+
+    for (const par of plParents) {
+      if (!hp.includes(par)) {
+        issues.push({
+          kind: 'lookup_parent_not_on_household',
+          playerEmail: pem,
+          householdId: plHid,
+          parentEmail: par,
+          fix: 'repairHouseholdMembership or director linkHousehold',
+        });
+      }
+    }
+  }
+
+  const byKind = new Map();
+  for (const row of issues) {
+    const k = String(row.kind);
+    byKind.set(k, (byKind.get(k) || 0) + 1);
+  }
+
+  console.log(`Total issues: ${issues.length}\n`);
+  for (const [kind, count] of [...byKind.entries()].sort()) {
+    console.log(`  ${kind}: ${count}`);
+  }
+  console.log('\nSample rows (up to 25):\n');
+  console.log(JSON.stringify(issues.slice(0, 25), null, 2));
+}
+
+main().catch((err) => {
+  console.error('[audit-household-graph] failed:', err);
+  process.exit(1);
+});

--- a/src/lib/household/__tests__/householdGraphLaunch.test.ts
+++ b/src/lib/household/__tests__/householdGraphLaunch.test.ts
@@ -43,6 +43,21 @@ describe('LAUNCH-household-graph — guardian visibility', () => {
 		expect(src).toMatch(/stampAllPlayerLookupGuardians/);
 	});
 
+	it('generatePlayerOTP reconciles household membership before rejecting', () => {
+		const membership = readFileSync(
+			join(process.cwd(), 'functions/src/domains/householdMembership.js'),
+			'utf-8',
+		);
+		const ops = readFileSync(
+			join(process.cwd(), 'functions/src/domains/operativeOps.js'),
+			'utf-8',
+		);
+		expect(membership).toMatch(/repairHouseholdMembership/);
+		expect(membership).toMatch(/linkedOnLookup/);
+		expect(ops).toMatch(/householdMembership/);
+		expect(ops).toMatch(/assertChildInParentHousehold\(actor, childUid, childEm\)/);
+	});
+
 	it('coach CommandCenter shows guardian and VPC roster columns', () => {
 		const src = readFileSync(
 			join(ROOT, 'lib/components/coach/CommandCenter.svelte'),

--- a/src/lib/household/__tests__/householdGraphLaunch.test.ts
+++ b/src/lib/household/__tests__/householdGraphLaunch.test.ts
@@ -52,10 +52,15 @@ describe('LAUNCH-household-graph — guardian visibility', () => {
 			join(process.cwd(), 'functions/src/domains/operativeOps.js'),
 			'utf-8',
 		);
+		const page = readFileSync(
+			join(ROOT, 'routes/(app)/parent/household/+page.svelte'),
+			'utf-8',
+		);
 		expect(membership).toMatch(/repairHouseholdMembership/);
-		expect(membership).toMatch(/linkedOnLookup/);
-		expect(ops).toMatch(/householdMembership/);
+		expect(membership).toMatch(/reconcileParentHouseholdGraph/);
+		expect(ops).toMatch(/parentReconcileHousehold/);
 		expect(ops).toMatch(/assertChildInParentHousehold\(actor, childUid, childEm\)/);
+		expect(page).toMatch(/parentReconcileHousehold/);
 	});
 
 	it('coach CommandCenter shows guardian and VPC roster columns', () => {

--- a/src/routes/(app)/parent/household/+page.svelte
+++ b/src/routes/(app)/parent/household/+page.svelte
@@ -44,6 +44,7 @@
 	const parentSignCoppaWaiver = httpsCallable(functions, 'parentSignCoppaWaiver');
 	const parentProvisionOperative = httpsCallable(functions, 'parentProvisionOperative');
 	const parentLinkOperativeToTeam = httpsCallable(functions, 'parentLinkOperativeToTeam');
+	const parentReconcileHousehold = httpsCallable(functions, 'parentReconcileHousehold');
 	const generatePlayerOTP = httpsCallable(functions, 'generatePlayerOTP');
 
 	const role = $derived(authStore.role);
@@ -284,6 +285,11 @@
 		void (async () => {
 			try {
 				// Match /parent/vpc — default `db` for households/{id} reads (not getActiveDb cell routing).
+				try {
+					await parentReconcileHousehold({});
+				} catch {
+					/* non-fatal — still load household doc below */
+				}
 				const result = await fetchHouseholdClearance(db, hid);
 				if (cancelled || gen !== clearanceFetchGeneration) return;
 				householdId = result.householdId;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Parents could see operatives on `/parent/household` and admin Global Users showed parent↔player linkage, but **Generate clearance code** failed with *"That player is not linked to your household."*

Two separate disconnects:

1. **JWT vs Firestore householdId** — household page reads `users/{parent}.householdId`; `generatePlayerOTP` originally gated on JWT `householdId` claims.
2. **Admin vs Parent OS graph** — admin player rows show guardians from denormalized `player_lookup.parentEmails`, while `/parent/household` only listed `households.playerEmails`. When those diverged, admin looked correct but the household page showed **no operatives**.

## Fix

- `assertParentAsync` — prefers Firestore `users/{email}.householdId`, falls back to JWT.
- `householdMembership.js` — auto-repair on OTP when users + lookup agree but `households.playerEmails` is stale.
- **`parentReconcileHousehold`** — on `/parent/household` load, server discovers athletes from `player_lookup` + `users` and heals `households.playerEmails` before rendering.
- `scripts/audit-household-graph.mjs` — read-only audit for disconnect diagnostics.

## Deployed to sports-skill-tracker-dev

- `compliance:generatePlayerOTP`
- `compliance:parentReconcileHousehold` (new)
- **Firebase Hosting** (household page now calls reconcile on load)

Hosting URL: https://sports-skill-tracker-dev.web.app

## Manual retest (phone)

1. Hard refresh `/parent/household` (or sign out/in).
2. **Active operatives** section should list linked athletes.
3. Tap **Generate clearance code**.

## Verify

```bash
node functions/src/middleware/__tests__/authBouncers.test.js
node functions/src/domains/__tests__/householdMembership.test.js
npm test -- src/lib/household/__tests__/householdGraphLaunch.test.ts
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ce90bbdd-d7b5-49cc-993b-cf57845b6064"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ce90bbdd-d7b5-49cc-993b-cf57845b6064"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

