### PR TITLE
fix: center "ACTIVE MISSIONS" header over mission deck

### DIFF
--- a/src/lib/components/player/dashboard/__tests__/playerHudSprint220.test.ts
+++ b/src/lib/components/player/dashboard/__tests__/playerHudSprint220.test.ts
@@ -167,7 +167,7 @@ describe.skip('Sprint 2.20b — VPP material lift (PLAYER_OS_FOUNDATION.md §2, 
 	});
 });
 
-describe('Sprint 2.20c — composition hotfix (HQ / Stats / Train)', () => {
+describe.skip('Sprint 2.20c — composition hotfix (HQ / Stats / Train)', () => {
 	it('OperativeHub.svelte .operative-hub does NOT use overflow: hidden', () => {
 		// Bug 1: overflow:hidden was clipping identity stage and mission rail content
 		// Scoped rule block for .operative-hub must use visible (or omit overflow altogether)

--- a/src/lib/components/player/dashboard/__tests__/playerHudSprint220.test.ts
+++ b/src/lib/components/player/dashboard/__tests__/playerHudSprint220.test.ts
@@ -167,7 +167,7 @@ describe.skip('Sprint 2.20b — VPP material lift (PLAYER_OS_FOUNDATION.md §2, 
 	});
 });
 
-describe.skip('Sprint 2.20c — composition hotfix (HQ / Stats / Train)', () => {
+describe('Sprint 2.20c — composition hotfix (HQ / Stats / Train)', () => {
 	it('OperativeHub.svelte .operative-hub does NOT use overflow: hidden', () => {
 		// Bug 1: overflow:hidden was clipping identity stage and mission rail content
 		// Scoped rule block for .operative-hub must use visible (or omit overflow altogether)

--- a/src/lib/styles/player-missions.css
+++ b/src/lib/styles/player-missions.css
@@ -254,6 +254,7 @@
 
 /* Sprint 2.20c — center "ACTIVE MISSIONS" label over the mission deck */
 .player-hud-root .quest-log-panel--premium .quest-log__head--embedded {
+	text-align: center;
 	position: relative;
 	z-index: 1;
 	padding-bottom: clamp(4px, 0.8vw, 6px);


### PR DESCRIPTION
Bug fix to center the "ACTIVE MISSIONS" text over the mission deck. Added `text-align: center;` to `.player-hud-root .quest-log-panel--premium .quest-log__head--embedded` inside `src/lib/styles/player-missions.css`. This successfully unbreaks the relevant QA test.

---
*PR created automatically by Jules for task [1430121210100118821](https://jules.google.com/task/1430121210100118821) started by @blueneekone*