### PR TITLE
Revert "fix: center "ACTIVE MISSIONS" header over mission deck"

### DIFF
--- a/src/lib/styles/player-missions.css
+++ b/src/lib/styles/player-missions.css
@@ -254,7 +254,6 @@
 
 /* Sprint 2.20c — center "ACTIVE MISSIONS" label over the mission deck */
 .player-hud-root .quest-log-panel--premium .quest-log__head--embedded {
-	text-align: center;
 	position: relative;
 	z-index: 1;
 	padding-bottom: clamp(4px, 0.8vw, 6px);


### PR DESCRIPTION
Reverts blueneekone/soccer_skills_tracker#26