### PR TITLE
🧪 Add test for pickDirectorClubId

### DIFF
--- a/src/lib/director/__tests__/pickDirectorClubId.test.ts
+++ b/src/lib/director/__tests__/pickDirectorClubId.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { pickDirectorClubId } from '../pickDirectorClubId.js';
+
+describe('pickDirectorClubId', () => {
+	it('should return activeCtx if present and not admin', () => {
+		const teamsStore = { loaded: false, clubs: [] };
+		const authStore = { userProfile: { clubId: 'profile-club' } };
+		const workspaceContextStore = { activeClubId: ' active-club ' };
+
+		const result = pickDirectorClubId(teamsStore, authStore, workspaceContextStore);
+		expect(result).toBe('active-club');
+	});
+
+	it('should return rawProfileId if activeCtx is missing and profileId is not admin', () => {
+		const teamsStore = { loaded: false, clubs: [] };
+		const authStore = { userProfile: { clubId: ' profile-club ' } };
+		const workspaceContextStore = { activeClubId: null };
+
+		const result = pickDirectorClubId(teamsStore, authStore, workspaceContextStore);
+		expect(result).toBe('profile-club');
+	});
+
+	it('should return rawProfileId if activeCtx is admin', () => {
+		const teamsStore = { loaded: false, clubs: [] };
+		const authStore = { userProfile: { clubId: 'profile-club' } };
+		const workspaceContextStore = { activeClubId: 'admin' };
+
+		const result = pickDirectorClubId(teamsStore, authStore, workspaceContextStore);
+		expect(result).toBe('profile-club');
+	});
+
+	it('should return empty string if no valid context/profile and teamsStore is not loaded', () => {
+		const teamsStore = { loaded: false, clubs: [{ id: 'club1' }] };
+		const authStore = { userProfile: null };
+		const workspaceContextStore = { activeClubId: null };
+
+		const result = pickDirectorClubId(teamsStore, authStore, workspaceContextStore);
+		expect(result).toBe('');
+	});
+
+	it('should return empty string if no valid context/profile and teamsStore has no clubs', () => {
+		const teamsStore = { loaded: true, clubs: [] };
+		const authStore = { userProfile: null };
+		const workspaceContextStore = { activeClubId: null };
+
+		const result = pickDirectorClubId(teamsStore, authStore, workspaceContextStore);
+		expect(result).toBe('');
+	});
+
+	it('should fallback to first club in teamsStore if context/profile are missing/admin', () => {
+		const teamsStore = { loaded: true, clubs: [{ id: 'club1' }, { id: 'club2' }] };
+		const authStore = { userProfile: { clubId: 'admin' } };
+		const workspaceContextStore = { activeClubId: 'admin' };
+
+		const result = pickDirectorClubId(teamsStore, authStore, workspaceContextStore);
+		expect(result).toBe('club1');
+	});
+
+	it('should return admin if activeCtx is admin and a club with id admin exists in teamsStore', () => {
+		const teamsStore = { loaded: true, clubs: [{ id: 'admin' }] };
+		const authStore = { userProfile: null };
+		const workspaceContextStore = { activeClubId: 'admin' };
+
+		const result = pickDirectorClubId(teamsStore, authStore, workspaceContextStore);
+		expect(result).toBe('admin');
+	});
+});


### PR DESCRIPTION
🎯 **What:** Added a missing test suite for `pickDirectorClubId`.
📊 **Coverage:** Tests verify prioritizing context switcher, profile club ID, and fallback to the first loaded club, as well as handling for missing/empty state or `admin` identifiers.
✨ **Result:** Improved test coverage for `pickDirectorClubId.js` with 7 new passing test cases ensuring all logic paths are verified.

---
*PR created automatically by Jules for task [4122855589928864184](https://jules.google.com/task/4122855589928864184) started by @blueneekone*