### PR TITLE
🔒 Prevent internal error leak in webhook response

### DIFF
--- a/functions-commerce/src/domains/webhooksOps.js
+++ b/functions-commerce/src/domains/webhooksOps.js
@@ -1452,7 +1452,7 @@ exports.stripeWebhook = onRequest(
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         logger.error(`Webhook signature verification failed: ${msg}`);
-        res.status(400).send(`Webhook Error: ${msg}`);
+        res.status(400).send('Webhook signature verification failed');
         return;
       }
 

--- a/functions/src/domains/webhooksOps.js
+++ b/functions/src/domains/webhooksOps.js
@@ -1452,7 +1452,7 @@ exports.stripeWebhook = onRequest(
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         logger.error(`Webhook signature verification failed: ${msg}`);
-        res.status(400).send(`Webhook Error: ${msg}`);
+        res.status(400).send('Webhook signature verification failed');
         return;
       }
 


### PR DESCRIPTION
🎯 **What:** 
The vulnerability fixed is an information disclosure via the Stripe webhook endpoint. The endpoint was returning the internal error message (e.g., stack trace or underlying system reason) directly to the client when signature verification failed.

⚠️ **Risk:** 
If left unfixed, an attacker sending malformed or forged webhooks could use the returned internal error strings to gain insights into the backend server's dependencies, versioning, or system configuration, potentially aiding further exploitation.

🛡️ **Solution:** 
The fix updates `webhooksOps.js` (in both the `functions` and `functions-commerce` services) so that when catching an error in `stripeClient.webhooks.constructEvent`, the full error is securely logged internally using `logger.error`, but the client is given a generic `400 Bad Request` response with the message `"Webhook signature verification failed"`.

---
*PR created automatically by Jules for task [3020890794250251804](https://jules.google.com/task/3020890794250251804) started by @blueneekone*