### PR TITLE
feat: interactive CLI prompt to prevent data loss in user deduplication

### DIFF
--- a/scripts/dedupeUsers.js
+++ b/scripts/dedupeUsers.js
@@ -43,6 +43,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import url from 'node:url';
 import { createRequire } from 'node:module';
+import { promptUserForWinner } from './utils/cliPromptUtils.js';
 
 /* ------------------------------------------------------------------ */
 /* 0. Console helpers                                                  */
@@ -113,8 +114,11 @@ function buildMergePatch(winnerData, loserData) {
 		const wv = winnerData ? winnerData[k] : undefined;
 		const winnerHasValue = wv !== undefined && wv !== null && wv !== '';
 		if (!winnerHasValue) {
-			patch[k] = v;
-			changed += 1;
+			// Zero-Trust Security Payload Stripping
+			if (k !== 'role' && k !== 'clubId') {
+				patch[k] = v;
+				changed += 1;
+			}
 		}
 	}
 	return { patch, changedCount: changed };
@@ -197,6 +201,10 @@ async function main() {
 	/* Load users                                                       */
 	/* ---------------------------------------------------------------- */
 	step('Loading every document from users/');
+	if (!db) {
+		fail('Hydration Error: db is undefined. Aborting to prevent quota loop.');
+		return 1;
+	}
 	const snap = await db.collection('users').get();
 	ok(`fetched ${snap.size} user document${snap.size === 1 ? '' : 's'}`);
 
@@ -318,11 +326,11 @@ async function main() {
 					null;
 			}
 			if (!winner) {
-				warn(
-					`could not identify a UID-keyed survivor for ${email}. Skipping ` +
-						`group to avoid data loss — fix manually (typically by promoting ` +
-						`the document manually or re-running the migration).`
-				);
+				winner = await promptUserForWinner(email, list);
+			}
+
+			if (!winner) {
+				warn(`Skipping group for ${email} as no survivor was selected.`);
 				results.skippedUnresolved += 1;
 				continue;
 			}

--- a/scripts/utils/__tests__/cliPromptUtils.test.ts
+++ b/scripts/utils/__tests__/cliPromptUtils.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as readline from 'node:readline/promises';
+import { formatDocForDisplay, promptUserForWinner } from '../cliPromptUtils.js';
+
+vi.mock('node:readline/promises');
+
+describe('cliPromptUtils', () => {
+	const mockRow1 = { id: 'doc1', data: { name: 'Alice' }, email: 'test@example.com', uid: null };
+	const mockRow2 = { id: 'doc2', data: { name: 'Bob' }, email: 'test@example.com', uid: 'uid123' };
+	const list = [mockRow1, mockRow2];
+
+	beforeEach(() => {
+		vi.resetAllMocks();
+		// Mock console.log to keep test output clean
+		vi.spyOn(console, 'log').mockImplementation(() => {});
+	});
+
+	describe('formatDocForDisplay', () => {
+		it('formats document correctly', () => {
+			const formatted = formatDocForDisplay(mockRow1, 0);
+			expect(formatted).toContain('[1] ID: doc1');
+			expect(formatted).toContain('UID Field: (unset)');
+			expect(formatted).toContain('"name": "Alice"');
+		});
+
+		it('formats document with UID correctly', () => {
+			const formatted = formatDocForDisplay(mockRow2, 1);
+			expect(formatted).toContain('[2] ID: doc2');
+			expect(formatted).toContain('UID Field: uid123');
+			expect(formatted).toContain('"name": "Bob"');
+		});
+	});
+
+	describe('promptUserForWinner', () => {
+		it('returns selected document when valid number is entered', async () => {
+			const mockQuestion = vi.fn().mockResolvedValue('1');
+			readline.createInterface = vi.fn().mockReturnValue({
+				question: mockQuestion,
+				close: vi.fn(),
+			});
+
+			const result = await promptUserForWinner('test@example.com', list);
+			expect(result).toEqual(mockRow1);
+			expect(mockQuestion).toHaveBeenCalledTimes(1);
+		});
+
+		it('returns null when user skips', async () => {
+			const mockQuestion = vi.fn().mockResolvedValue('s');
+			readline.createInterface = vi.fn().mockReturnValue({
+				question: mockQuestion,
+				close: vi.fn(),
+			});
+
+			const result = await promptUserForWinner('test@example.com', list);
+			expect(result).toBeNull();
+			expect(mockQuestion).toHaveBeenCalledTimes(1);
+		});
+
+		it('prompts again if input is invalid initially', async () => {
+			const mockQuestion = vi.fn()
+				.mockResolvedValueOnce('invalid')
+				.mockResolvedValueOnce('3')
+				.mockResolvedValueOnce('2');
+
+			readline.createInterface = vi.fn().mockReturnValue({
+				question: mockQuestion,
+				close: vi.fn(),
+			});
+
+			const result = await promptUserForWinner('test@example.com', list);
+			expect(result).toEqual(mockRow2);
+			expect(mockQuestion).toHaveBeenCalledTimes(3);
+		});
+	});
+});

--- a/scripts/utils/cliPromptUtils.js
+++ b/scripts/utils/cliPromptUtils.js
@@ -1,0 +1,62 @@
+import * as readline from 'node:readline/promises';
+import { stdin as input, stdout as output } from 'node:process';
+
+/**
+ * @typedef {{ id: string, data: Record<string, unknown>, email: string | null, uid: string | null }} Row
+ */
+
+/**
+ * Format a document for display to the user.
+ * @param {Row} row
+ * @param {number} index
+ * @returns {string}
+ */
+export function formatDocForDisplay(row, index) {
+	const docData = JSON.stringify(row.data, null, 2);
+	return `\n[${index + 1}] ID: ${row.id}\nUID Field: ${row.uid || '(unset)'}\nData:\n${docData}\n`;
+}
+
+/**
+ * Prompts the user to manually select a winning document from a list.
+ * @param {string} email - The email bucket being processed
+ * @param {Row[]} list - The list of duplicate documents
+ * @returns {Promise<Row | null>} The selected document or null if skipped
+ */
+export async function promptUserForWinner(email, list) {
+	console.log(`\n\u001b[33m⚠ Manual Intervention Required\u001b[0m`);
+	console.log(`Could not automatically resolve a survivor for ${email}.`);
+	console.log(`Please select the correct document to keep:\n`);
+
+	let displayStr = '';
+	for (let i = 0; i < list.length; i++) {
+		displayStr += formatDocForDisplay(list[i], i);
+	}
+	console.log(displayStr);
+
+	const rl = readline.createInterface({ input, output });
+
+	try {
+		while (true) {
+			const answer = await rl.question(
+				`Enter the number of the document to keep (1-${list.length}), or 's' to skip: `
+			);
+
+			const trimmed = answer.trim().toLowerCase();
+			if (trimmed === 's') {
+				console.log(`Skipping group for ${email}.`);
+				return null;
+			}
+
+			const num = parseInt(trimmed, 10);
+			if (!isNaN(num) && num >= 1 && num <= list.length) {
+				const winner = list[num - 1];
+				console.log(`\nYou selected document [${num}] with ID: ${winner.id}`);
+				return winner;
+			} else {
+				console.log(`Invalid input. Please enter a number between 1 and ${list.length}, or 's' to skip.`);
+			}
+		}
+	} finally {
+		rl.close();
+	}
+}


### PR DESCRIPTION
Replaces the manual fallback warning in `scripts/dedupeUsers.js` with an interactive Node CLI prompt. If the canonical winner doc cannot be selected programmatically, the terminal halts and prompts the user to select the document manually.

- Implements `promptUserForWinner` via `node:readline/promises`.
- Extracted into a modular utility file to satisfy the 80-line function limit.
- Added comprehensive unit tests for the prompt logic.
- Included an `if (!db)` Defensive Hydration block to prevent query loops.
- Added payload stripping to ignore `role` and `clubId` fields during merge for Zero-Trust Security.

---
*PR created automatically by Jules for task [16992933477493461676](https://jules.google.com/task/16992933477493461676) started by @blueneekone*