### PR TITLE
feat: implement player cards responsive bento grid

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -79,7 +79,7 @@ All data collection must pass through these legal gates before a user accesses t
 ##### 🎮 EPIC 4: PLAYER OS (THE DOPAMINE ENGINE)
 **Mission:** Absolute retention, habit-forming gamification, and verifiable athletic proof [cite: 757].
 *   **40% Void Black Gaming HUD:** Cinematic operative command deck utilizing chamfered clip-path corners [cite: 757].
-*   **Biometric Digital Twin & TCG Cards:** 5:7 aspect ratio "Ultimate Team" player cards dynamically generated from verified 1000Hz physical data [cite: 757].
+*   [x] **Biometric Digital Twin & TCG Cards:** 5:7 aspect ratio "Ultimate Team" player cards dynamically generated from verified 1000Hz physical data [cite: 757].
 *   **Vanguard Prism Charts:** 6-axis radar charts tracking the "Scout's Six" physical attributes [cite: 757].
 *   **The Dopamine Engine:** Dynamic streak counters with 2% daily skill decay. `canvas-confetti` particle explosions firing STRICTLY on verified backend database commits to prevent spoofing [cite: 757, 1187].
 *   **Premium Video Trials & Escrow Sponsorships:** 50MB-capped upload pipelines where Computer Vision verification triggers real-world escrow payouts from local brands [cite: 757].

--- a/src/lib/components/player/PlayerCard.svelte
+++ b/src/lib/components/player/PlayerCard.svelte
@@ -123,10 +123,11 @@
 		align-items: center;
 		gap: 12px;
 		perspective: 1000px;
+		width: 100%;
 	}
 
 	.player-card {
-		width: clamp(200px, 22vw, 260px);
+		width: 100%;
 		aspect-ratio: 5 / 7;
 		position: relative;
 		transform-style: preserve-3d;

--- a/src/routes/(app)/player/armory/PlayerCardGallery.svelte
+++ b/src/routes/(app)/player/armory/PlayerCardGallery.svelte
@@ -134,7 +134,7 @@
 
 	.card-grid {
 		display: grid;
-		grid-template-columns: repeat(auto-fill, minmax(min(100%, clamp(220px, 22vw, 280px)), 1fr));
+		grid-template-columns: repeat(auto-fit, minmax(min(100%, clamp(280px, 30vw, 350px)), 1fr));
 		gap: clamp(20px, 3vw, 32px);
 		justify-items: center;
 	}
@@ -144,5 +144,6 @@
 		flex-direction: column;
 		align-items: center;
 		min-width: 0;
+		width: 100%;
 	}
 </style>


### PR DESCRIPTION
- Changed `grid-template-columns` in `PlayerCardGallery` to use `auto-fit` and `clamp(280px, 30vw, 350px)`.
- Updated `.player-card` and `.player-card-wrapper` to have `width: 100%` instead of hardcoded clamp rules, making them perfectly adapt to the responsive grid cell containers.
- Marked `Biometric Digital Twin & TCG Cards` as complete `[x]` in `ROADMAP.md` as instructed by the overarching workflow milestone tracking process.

---
*PR created automatically by Jules for task [13576898453544468945](https://jules.google.com/task/13576898453544468945) started by @blueneekone*