### PR TITLE
fix: resolve infinite "Loading teams..." state for directors on Team Ops page

### DIFF
--- a/src/lib/stores/teams.svelte.js
+++ b/src/lib/stores/teams.svelte.js
@@ -192,7 +192,10 @@ export function resolveTeamsLoadScope(pathname, role) {
 		return 'admin_full';
 	}
 	if (pathname.startsWith('/director')) return 'club';
-	if (pathname.startsWith('/coach')) return 'coach';
+	if (pathname.startsWith('/coach')) {
+		if (role === 'director' || role === 'registrar') return 'club';
+		return 'coach';
+	}
 	if (pathname.startsWith('/recruiter')) return 'none';
 	if (role === 'director' || role === 'registrar') return 'club';
 	if (role === 'coach') return 'coach';


### PR DESCRIPTION
Fixes an issue where navigating to `/coach/logistics` as a director/registrar would indefinitely show "Loading teams...".

Root Cause: 
When a director accessed `/coach/*` routes, `resolveTeamsLoadScope` strictly returned `'coach'` scope. The underlying `teamsStore` then attempted to query teams via `coachEmail`, which the director role does not natively permit outside of their club context. Because the Firestore `PERMISSION_DENIED` error bypassed setting `loaded = true`, the loading UI never resolved.

Solution:
Updated `resolveTeamsLoadScope` to fallback to `'club'` scope for `director` and `registrar` roles when on `/coach/*` routes. This ensures the component mounts correctly and utilizes their broader club data access.

---
*PR created automatically by Jules for task [7244398074162783181](https://jules.google.com/task/7244398074162783181) started by @blueneekone*