### PR TITLE
🧪 test: cover passkey enrollment player exemption exception path

### DIFF
--- a/src/lib/auth/__tests__/passkeyGate.test.ts
+++ b/src/lib/auth/__tests__/passkeyGate.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { requiresPasskeyEnrollmentBeforeApp } from '../passkeyGate.js';
+import { authStore } from '$lib/stores/auth.svelte.js';
+import { getIdTokenResult } from 'firebase/auth';
+import * as firestore from 'firebase/firestore';
+
+vi.mock('firebase/auth', () => ({
+	getIdTokenResult: vi.fn()
+}));
+
+vi.mock('$lib/stores/auth.svelte.js', () => ({
+	authStore: {
+		role: ''
+	}
+}));
+
+vi.mock('firebase/firestore', () => ({
+	collection: vi.fn(),
+	getDocs: vi.fn(),
+	limit: vi.fn(),
+	query: vi.fn()
+}));
+
+vi.mock('$lib/firebase.js', () => ({
+	db: {}
+}));
+
+describe('passkeyGate', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        authStore.role = '';
+    });
+
+	it('returns true if user needs enrollment', async () => {
+        const mockUser = {
+            uid: '123',
+            providerData: [{ providerId: 'password' }]
+        };
+        (firestore.getDocs as any).mockResolvedValueOnce({ empty: true });
+        (getIdTokenResult as any).mockResolvedValue({ claims: { role: 'coach' } });
+
+        const result = await requiresPasskeyEnrollmentBeforeApp(mockUser as any);
+        expect(result).toBe(true);
+	});
+
+    it('handles exception in isPlayerRoleExempt and returns false for exemption', async () => {
+        const mockUser = {
+            uid: '123',
+            providerData: [{ providerId: 'password' }]
+        };
+        (firestore.getDocs as any).mockResolvedValueOnce({ empty: true });
+
+        // Mock getIdTokenResult for isPlatformOperatorExempt
+        (getIdTokenResult as any).mockResolvedValueOnce({ claims: { role: 'coach' } });
+
+        // Mock getIdTokenResult for isPlayerRoleExempt to throw
+        (getIdTokenResult as any).mockRejectedValueOnce(new Error('Firebase error'));
+
+        const result = await requiresPasskeyEnrollmentBeforeApp(mockUser as any);
+        expect(result).toBe(true);
+    });
+});


### PR DESCRIPTION
🎯 **What:** Adds a test to cover the `catch` block in `isPlayerRoleExempt` inside `src/lib/auth/passkeyGate.ts`.
📊 **Coverage:** The test ensures that if `getIdTokenResult` throws an exception when checking if a user is player exempt, the function correctly returns false and the parent `requiresPasskeyEnrollmentBeforeApp` resolves to true.
✨ **Result:** Increased test coverage for authentication resilience.

---
*PR created automatically by Jules for task [5608370021543041203](https://jules.google.com/task/5608370021543041203) started by @blueneekone*