### PR TITLE
🧪 [testing improvement] Add test for Player OS write error catching

### DIFF
--- a/src/lib/player/__tests__/workoutLog.test.ts
+++ b/src/lib/player/__tests__/workoutLog.test.ts
@@ -218,4 +218,47 @@ describe('workoutLog', () => {
 			workoutLogErrorMessage({ message: 'Just a random message.' })
 		).toBe('Just a random message.');
 	});
+
+
+	it('executePlayerWorkoutLog catches and logs errors when Player OS write fails', async () => {
+		const logSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		const mockError = new Error('Simulated Player OS write failure');
+
+		const logTrainingSession = vi.fn(async () => {
+			return { data: { earnedXP: 42, totalXp: 500, level: 3 } } as any;
+		});
+
+		const writePlayerOsWorkout = vi.fn().mockRejectedValue(mockError);
+
+		const result = await executePlayerWorkoutLog({
+			drillType: '[Technical] Juggling (Player workout)',
+			durationMin: 30,
+			totalReps: 0,
+			intensityCall: 'medium',
+			focusLabel: 'Technical',
+			selectedDrill: 'Juggling',
+			activeMissionId: null,
+			missionSource: null,
+			totalXpHud: 458,
+			oldLevel: 3,
+			intensityStep: 7,
+			authUser: { uid: 'player-1', email: 'ace@example.com' },
+			profile: { teamId: 'team-1', playerName: 'Ace' },
+			logTrainingSession,
+			writePlayerOsWorkout,
+			commitWorkoutCompletion: vi.fn(),
+			dopamineOnCommit: vi.fn(async (p) => p),
+		});
+
+		expect(writePlayerOsWorkout).toHaveBeenCalled();
+		expect(logSpy).toHaveBeenCalledWith(
+			'[Player OS] users/',
+			'ace@example.com',
+			'/workouts',
+			mockError
+		);
+		expect(result.earned).toBe(42);
+
+		logSpy.mockRestore();
+	});
 });


### PR DESCRIPTION
🎯 **What:** The missing test coverage for the Player OS write error catching in `executePlayerWorkoutLog` (specifically catching the rejection of `writePlayerOsWorkout`) has been addressed.
📊 **Coverage:** The new test suite scenario covers the execution path where `writePlayerOsWorkout` rejects. It validates that `console.error` is accurately called with `[Player OS] users/`, the lowercase user email, `/workouts`, and the error instance, verifying that the rejection doesn't halt the flow.
✨ **Result:** Improved test coverage and reinforced robustness, ensuring regressions don't un-catch the error logging functionality for the `persistPlayerOsWorkout` sub-routine.

---
*PR created automatically by Jules for task [3151602565905136667](https://jules.google.com/task/3151602565905136667) started by @blueneekone*