### PR TITLE
Fix: Implement sub-10 word brutalist headline

### DIFF
--- a/src/routes/(marketing)/+page.svelte
+++ b/src/routes/(marketing)/+page.svelte
@@ -77,7 +77,7 @@
 
 			<!-- FIX #3: Sub-10 word brutalist headline -->
 			<h1 class="tw-text-4xl md:tw-text-5xl tw-font-bold tw-text-[#f8fafc] tw-tracking-tight tw-leading-[1.05] tw-max-w-4xl">
-				Stop managing teams. Start developing athletes. The Youth Sports OS.
+				Stop managing. Start developing. The Youth Sports OS.
 			</h1>
 
 			<p class="tw-text-[#94a3b8] tw-text-lg tw-max-w-2xl tw-leading-relaxed">


### PR DESCRIPTION
This PR modifies the hero headline on the marketing page to be "Stop managing. Start developing. The Youth Sports OS.", reducing the word count to 8 and aligning with the brutalist tone.

---
*PR created automatically by Jules for task [9058705281444245996](https://jules.google.com/task/9058705281444245996) started by @blueneekone*