### PR TITLE
Fix product preview image

### DIFF
--- a/src/routes/(marketing)/+page.svelte
+++ b/src/routes/(marketing)/+page.svelte
@@ -107,7 +107,7 @@
 			<div class="tw-absolute tw-inset-0 tw-bg-gradient-to-tr tw-from-[#02061799] tw-to-transparent tw-z-10 tw-pointer-events-none tw-transition-opacity tw-duration-700 group-hover:tw-opacity-30"></div>
 			<!-- Generated product preview -->
 			<div class="tw-w-full tw-h-full tw-flex tw-items-center tw-justify-center tw-bg-[#000000] tw-transition-transform tw-duration-700 group-hover:tw-scale-[1.02]">
-				<video src="/nexus-command-preview.mp4" autoplay loop muted playsinline class="tw-w-full tw-h-full tw-object-cover"></video>
+				<img src="https://images.unsplash.com/photo-1518605368461-1e1e38ce81b5?ixlib=rb-4.0.3&auto=format&fit=crop&w=1280&q=80" alt="Product Preview" class="tw-w-full tw-h-full tw-object-cover tw-opacity-80" />
 			</div>
 			<!-- Scanline overlay -->
 			<div class="tw-absolute tw-inset-0 tw-z-10 tw-pointer-events-none" style="opacity: 0.03; background: repeating-linear-gradient(0deg, transparent, transparent 3px, #fff 3px, #fff 4px);"></div>


### PR DESCRIPTION
Replaced the missing video file with an Unsplash image asset on the marketing page to simulate a real product preview.

---
*PR created automatically by Jules for task [18143721739031776406](https://jules.google.com/task/18143721739031776406) started by @blueneekone*