### PR TITLE
🔒 Fix insecure randomness for token generation

### DIFF
--- a/src/lib/states/ArmoryEngine.svelte.ts
+++ b/src/lib/states/ArmoryEngine.svelte.ts
@@ -730,9 +730,7 @@ export class ArmoryEngine {
 		const historyRef = doc(collection(db, PATHS.userXpHistory(this.userKey)));
 
 		const batchId =
-			typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
-				? crypto.randomUUID()
-				: `xp-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+			crypto.randomUUID();
 
 		const batch = writeBatch(db);
 


### PR DESCRIPTION
🎯 What: Removed the insecure fallback to `Math.random().toString(36)` for generating `batchId`s in `src/lib/states/ArmoryEngine.svelte.ts`.
⚠️ Risk: Predictable random IDs could lead to token collisions or ID prediction attacks.
🛡️ Solution: Updated the code to directly use the cryptographically secure `crypto.randomUUID()` method.

---
*PR created automatically by Jules for task [2897779108607048677](https://jules.google.com/task/2897779108607048677) started by @blueneekone*