### PR TITLE
🧪 Testing Improvement: test auth routeByFirestoreRole exception catch fallback

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -98,3 +98,4 @@ All data collection must pass through these legal gates before a user accesses t
 *   **Auto-Tracking Camera Integration:** Seamless software hooks for AI-driven smart cameras to automatically record and livestream matches [cite: 759].
 *   **Interactive Broadcast Engine:** Gamification overlays on live streams allowing remote fans to vote on MVP and react with digital confetti [cite: 759].
 *   **Frictionless Digital Ticketing & Superdraws:** Embedded QR-code ticketing and 60-minute digital fundraising campaigns [cite: 759].
+*   [x] **Testing Improvement:** Added catch block test for auth routeByFirestoreRole fetch failure.

--- a/src/lib/auth/__tests__/authRouter.test.ts
+++ b/src/lib/auth/__tests__/authRouter.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { routeByFirestoreRole } from '../authRouter';
+import { goto } from '$app/navigation';
+import { getDoc } from 'firebase/firestore';
+
+vi.mock('$app/environment', () => ({
+	browser: true
+}));
+
+vi.mock('$app/navigation', () => ({
+	goto: vi.fn()
+}));
+
+vi.mock('firebase/firestore', () => ({
+	doc: vi.fn(),
+	getDoc: vi.fn()
+}));
+
+vi.mock('$lib/firebase/config', () => ({
+	db: {}
+}));
+
+describe('routeByFirestoreRole exception handling', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('routes to /onboarding if getDoc throws an exception (catch block)', async () => {
+		vi.mocked(getDoc).mockRejectedValueOnce(new Error('Network Error'));
+
+		const mockUser = { email: 'test@example.com' } as any;
+
+		await routeByFirestoreRole(mockUser);
+
+		expect(goto).toHaveBeenCalledWith('/onboarding', { replaceState: true });
+	});
+});


### PR DESCRIPTION
🎯 **What:** The `routeByFirestoreRole` auth routing component lacked test coverage for its exception handling when a Firestore fetch (e.g. `getDoc`) fails.
📊 **Coverage:** A dedicated test suite was created in `src/lib/auth/__tests__/authRouter.test.ts`. This suite effectively isolates the Sveltekit navigation aliases and tests that `routeByFirestoreRole` invokes `goto('/onboarding', { replaceState: true })` in its catch block when an unexpected error is thrown during document reads.
✨ **Result:** Better reliability tracking and regression prevention on critical user-redirection logic. The `catch` block is now confirmed to gracefully handle network failures or unavailable user profiles.

---
*PR created automatically by Jules for task [1905031213484750573](https://jules.google.com/task/1905031213484750573) started by @blueneekone*