### PR TITLE
chore: audit parent os compliance shield

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -105,4 +105,4 @@ All data collection must pass through these legal gates before a user accesses t
 *   [x] **Testing Improvement:** Added catch block test for auth routeByFirestoreRole fetch failure.
 
 
-*   [x] **Jules Comprehensive Brain Audit:** Reviewed backend integrations for the Coach OS (SafeSport Shadow CC) are successfully complete.
+*   [x] **Jules Comprehensive Brain Audit:** Reviewed backend integrations for the Coach OS (SafeSport Shadow CC) and Parent OS (Compliance Shield) are successfully complete.

--- a/src/lib/services/__tests__/parent-vault.test.ts
+++ b/src/lib/services/__tests__/parent-vault.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { CarRideEngine, type PublicScore } from '../../../routes/(app)/parent/dashboard/CarRideEngine.svelte';
+import { Timestamp } from 'firebase/firestore';
+import { deriveIsConsented } from '../../../lib/stores/auth/roleDerivations';
+
+describe('Car Ride Home Protocol Embargo Gates', () => {
+    it('locks out match metric dashboards for exactly 15 minutes post-game', () => {
+        const engine = new CarRideEngine();
+
+        // Match recorded 14 minutes ago
+        engine.publicScore = {
+            recordedAt: Timestamp.fromMillis(Date.now() - 14 * 60 * 1000)
+        } as PublicScore;
+        expect(engine.isTemporallyEmbargoed).toBe(true);
+
+        // Match recorded 16 minutes ago
+        engine.publicScore = {
+            recordedAt: Timestamp.fromMillis(Date.now() - 16 * 60 * 1000)
+        } as PublicScore;
+        expect(engine.isTemporallyEmbargoed).toBe(false);
+    });
+
+    it('unauthenticated calls bypass the timestamp check and return empty states', async () => {
+        const engine = new CarRideEngine();
+        await engine.init('player@example.com', 'tenant1', 'club1');
+
+        expect(engine.lockedMetrics).toBeNull();
+    });
+});
+
+describe('COPPA 2.0 / VPC Verification', () => {
+    it('pauses player data collection until VPC is authenticated', () => {
+        // Player, minor, COPPA granted but VPC pending -> blocked
+        expect(deriveIsConsented({
+            isAuthenticated: true,
+            isLoading: false,
+            role: 'player',
+            userProfile: { isMinor: true, coppaStatus: 'granted', vpcStatus: 'pending' }
+        })).toBe(false);
+
+        // Player, minor, COPPA pending but VPC verified -> blocked
+        expect(deriveIsConsented({
+            isAuthenticated: true,
+            isLoading: false,
+            role: 'player',
+            userProfile: { isMinor: true, coppaStatus: 'pending', vpcStatus: 'verified' }
+        })).toBe(false);
+
+        // Player, minor, COPPA granted and VPC verified -> allowed
+        expect(deriveIsConsented({
+            isAuthenticated: true,
+            isLoading: false,
+            role: 'player',
+            userProfile: { isMinor: true, coppaStatus: 'granted', vpcStatus: 'verified' }
+        })).toBe(true);
+
+        // Non-minors always pass
+        expect(deriveIsConsented({
+            isAuthenticated: true,
+            isLoading: false,
+            role: 'player',
+            userProfile: { isMinor: false, coppaStatus: 'pending', vpcStatus: 'pending' }
+        })).toBe(true);
+    });
+});

--- a/src/routes/(app)/parent/dashboard/CarRideEngine.svelte.ts
+++ b/src/routes/(app)/parent/dashboard/CarRideEngine.svelte.ts
@@ -1,3 +1,4 @@
+// 🛡️ SafeSport Compliance Mandate
 /**
  * CarRideEngine.svelte.ts — Phase 4, Epic 8: The Car Ride Home Protocol
  * ───────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Chore: Added tests for Parent OS `CarRideEngine` to assert 15 minute match metrics embargo, added assertions for `COPPA 2.0 / VPC` in `roleDerivations.ts` halting data collection until verification. Prepended safe sport comment to `CarRideEngine.svelte.ts` and updated `ROADMAP.md` indicating completion.

---
*PR created automatically by Jules for task [1166930712075188194](https://jules.google.com/task/1166930712075188194) started by @blueneekone*