### PR TITLE
feat: Implement team-isolated expanded staff controls

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -107,3 +107,4 @@ All data collection must pass through these legal gates before a user accesses t
 
 
 *   [x] **Jules Comprehensive Brain Audit:** Reviewed backend integrations for the Coach OS (SafeSport Shadow CC) and Parent OS (Compliance Shield) are successfully complete.
+*   [x] **Coach Expanded Staff Controls:** Implement team-isolated staff permissions, update Firestore security rules, and generate the corresponding integration tests.

--- a/firestore.rules
+++ b/firestore.rules
@@ -482,7 +482,9 @@ service cloud.firestore {
           || get(/databases/$(database)/documents/teams/$(tid)).data.get('coachEmail', '').lower()
                == emailKey()
           || (get(/databases/$(database)/documents/teams/$(tid)).data.keys().hasAll(['assistants'])
-              && get(/databases/$(database)/documents/teams/$(tid)).data.assistants.hasAny([emailKey()])));
+              && get(/databases/$(database)/documents/teams/$(tid)).data.assistants.hasAny([emailKey()]))
+          || (get(/databases/$(database)/documents/teams/$(tid)).data.keys().hasAll(['expandedStaff'])
+              && get(/databases/$(database)/documents/teams/$(tid)).data.expandedStaff.hasAny([emailKey()])));
     }
 
     // Team channel matrix: teams/{teamId}/channels/{channelId}/messages

--- a/src/lib/coach/__tests__/coachExpandedStaffControls.test.ts
+++ b/src/lib/coach/__tests__/coachExpandedStaffControls.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { readFileSync } from 'fs';
+import { initializeTestEnvironment, RulesTestEnvironment, assertSucceeds, assertFails } from '@firebase/rules-unit-testing';
+import { setDoc, doc, getDoc } from 'firebase/firestore';
+
+let testEnv: RulesTestEnvironment;
+
+beforeAll(async () => {
+    const rules = readFileSync('firestore.rules', 'utf8');
+    testEnv = await initializeTestEnvironment({
+        projectId: 'soccer-skills-tracker',
+        firestore: { rules }
+    });
+}, 30000);
+
+afterAll(async () => {
+    if (testEnv) {
+        await testEnv.cleanup();
+    }
+});
+
+describe('coachExpandedStaffControls', () => {
+    it('allows a coach in the expandedStaff list to read the team document', async () => {
+        await testEnv.withSecurityRulesDisabled(async (context) => {
+            const db = context.firestore();
+            await setDoc(doc(db, 'teams', 'teamA'), {
+                clubId: 'clubA',
+                coachEmail: 'headcoach@test.com',
+                expandedStaff: ['expandedcoach@test.com']
+            });
+            await setDoc(doc(db, 'users', 'expandedcoach@test.com'), {
+                role: 'coach',
+                clubId: 'clubA'
+            });
+        });
+
+        const expandedCoachContext = testEnv.authenticatedContext('expandedcoach_uid', {
+            email: 'expandedcoach@test.com',
+            role: 'coach',
+            clubId: 'clubA'
+        });
+
+        const db = expandedCoachContext.firestore();
+        const teamDocRef = doc(db, 'teams', 'teamA');
+
+        await assertSucceeds(getDoc(teamDocRef));
+    });
+
+    it('allows a coach in the expandedStaff list to read team workouts', async () => {
+        await testEnv.withSecurityRulesDisabled(async (context) => {
+            const db = context.firestore();
+            await setDoc(doc(db, 'team_workouts', 'workoutA'), {
+                teamId: 'teamA',
+                clubId: 'clubA'
+            });
+        });
+
+        const expandedCoachContext = testEnv.authenticatedContext('expandedcoach_uid', {
+            email: 'expandedcoach@test.com',
+            role: 'coach',
+            clubId: 'clubA'
+        });
+
+        const db = expandedCoachContext.firestore();
+        const workoutDocRef = doc(db, 'team_workouts', 'workoutA');
+
+        await assertSucceeds(getDoc(workoutDocRef));
+    });
+
+    it('denies access to a coach not in the expandedStaff list', async () => {
+        const unrelatedCoachContext = testEnv.authenticatedContext('unrelated_uid', {
+            email: 'unrelated@test.com',
+            role: 'coach',
+            clubId: 'clubB'
+        });
+
+        const db = unrelatedCoachContext.firestore();
+        const teamDocRef = doc(db, 'teams', 'teamA');
+
+        await assertFails(getDoc(teamDocRef));
+    });
+});


### PR DESCRIPTION
Implement team-isolated staff permissions, update our Firestore security rules, and generate the corresponding integration tests.

### What has changed?
1. Modified `firestore.rules` for the function `coachStaffCanAccessTeam` to check if a user is within the `expandedStaff` array on the target team document.
2. Created a new tests file `src/lib/coach/__tests__/coachExpandedStaffControls.test.ts` to implement tests against `expandedStaff` modifications and the related rules changes using the `firebase/rules-unit-testing` framework.
3. Updated `ROADMAP.md` task states indicating workflow completion.

---
*PR created automatically by Jules for task [338656750515950039](https://jules.google.com/task/338656750515950039) started by @blueneekone*