### PR TITLE
🧪 test(director): improve evaluateClubEligibility test coverage for SafeSport checks

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -105,6 +105,7 @@ All data collection must pass through these legal gates before a user accesses t
 *   **Frictionless Digital Ticketing & Superdraws:** Embedded QR-code ticketing and 60-minute digital fundraising campaigns [cite: 759].
 *   [x] **Testing Improvement:** Added catch block test for auth routeByFirestoreRole fetch failure.
 *   [x] **Testing Improvement:** Added comprehensive edge case tests for `evaluateClubEligibility.js` to ensure 100% logic coverage.
+*   [x] **Testing Improvement:** Added missing branch test for valid SafeSport clearance in `evaluateClubEligibility.js`.
 
 
 *   [x] **Jules Comprehensive Brain Audit:** Reviewed backend integrations for the Coach OS (SafeSport Shadow CC) and Parent OS (Compliance Shield) are successfully complete.

--- a/src/lib/director/__tests__/evaluateClubEligibility.test.ts
+++ b/src/lib/director/__tests__/evaluateClubEligibility.test.ts
@@ -111,6 +111,11 @@ describe('evaluateClubEligibility', () => {
 			expect(result).toEqual({ eligible: false, blockers: ['safesport_pending'] });
 		});
 
+		it('should return eligible for cleared safesport clearance', () => {
+			const result = evaluateClubEligibility({ ...baseInput, clearanceStatus: 'CLEARED' }, DEFAULT_ELIGIBILITY_MATRIX);
+			expect(result).toEqual({ eligible: true, blockers: [] });
+		});
+
 		it('should return vpc_not_verified blocker for minors without verified vpc', () => {
 			const result = evaluateClubEligibility({ ...baseInput, isMinor: true, vpcStatus: 'pending' }, DEFAULT_ELIGIBILITY_MATRIX);
 			expect(result).toEqual({ eligible: false, blockers: ['vpc_not_verified'] });


### PR DESCRIPTION
🎯 **What:** This PR addresses a testing gap in `evaluateClubEligibility.js` where the logic verifying that a valid SafeSport clearance (`clearanceStatus === 'CLEARED'`) properly grants eligibility without blockers was missing test coverage.
📊 **Coverage:** A new test case has been added to `evaluateClubEligibility.test.ts` to assert that when `requireSafeSportClearance` is true, a guardian is linked, and `clearanceStatus` is set to `'CLEARED'`, the function accurately evaluates eligibility as `true` and returns an empty `blockers` array. This covers the remaining branch condition that does not match `'RED_CARD'` or `'PENDING_SAFESPORT'`.
✨ **Result:** Test coverage for the SafeSport evaluation logic is now functionally complete, ensuring deterministic behavior and preventing future regressions in this specific compliance check.

---
*PR created automatically by Jules for task [4108183794023759653](https://jules.google.com/task/4108183794023759653) started by @blueneekone*