### PR TITLE
build Fan OS live MVP voting engine

### DIFF
--- a/src/routes/(app)/fan/watch/BroadcastEngine.svelte.ts
+++ b/src/routes/(app)/fan/watch/BroadcastEngine.svelte.ts
@@ -11,13 +11,104 @@ export class BroadcastEngine {
 	#campaignDoc = $state<SuperdrawCampaign | null>(null);
 	#unsubs: (() => void)[] = [];
 
-	isVotingOpen = $derived(this.#sessionDoc?.mvpVoting?.votingActive ?? false);
+	// Subscriptions for candidate profile documents
+	#candidateProfiles = $state<Record<string, any>>({});
+	#candidateUnsubs: Record<string, () => void> = {};
+
+	// Batching queues for rapid sequential votes
+	#pendingVotes: { candidatePlayerUid: string; resolve: (val: boolean) => void; reject: (err: any) => void }[] = [];
+	#batchTimeout: any = null;
+
+	// Manage voting states (votingActive, candidates, results) as Svelte 5 reactive states/derived fields
+	votingActive = $derived(this.#sessionDoc?.mvpVoting?.votingActive ?? false);
+	results = $derived<Record<string, number>>(this.#sessionDoc?.mvpVoting?.results ?? {});
+
+	// Protect minor player PII. When rendering candidates, map and display only pseudonymized metrics or vetted player-card profiles
+	candidates = $derived(
+		(this.#sessionDoc?.mvpVoting?.candidates ?? []).map((cand) => {
+			const id = typeof cand === 'string' ? cand : cand.id;
+			const profile = this.#candidateProfiles[id] || (typeof cand === 'object' ? cand : null);
+
+			if (profile) {
+				const isMinor = profile.isMinor === true;
+				const coppaOk = profile.coppaStatus === 'granted';
+				const vpcOk = profile.vpcStatus === 'verified' || profile.vpcStatus === 'not_required';
+				const isConsented = coppaOk && vpcOk;
+
+				if (isMinor) {
+					// COPPA 2.0 Broadcast Shield: Broadcast metrics and live streams must strictly render
+					// pseudonymized telemetry and verified player-card profiles; never expose PII of minor athletes.
+					return {
+						id,
+						name: isConsented && profile.playerName
+							? this._maskName(profile.playerName)
+							: `Athlete #${id.substring(0, 4) || 'Anon'}`,
+						isMinor: true,
+						isConsented,
+						stats: isConsented && profile.vettedStats
+							? profile.vettedStats
+							: this._pseudonymizeStats(profile.stats),
+						telemetry: isConsented && profile.vettedTelemetry
+							? profile.vettedTelemetry
+							: this._pseudonymizeTelemetry(profile.telemetry)
+					};
+				} else {
+					// Adult player
+					return {
+						id,
+						name: profile.name || profile.playerName || `Candidate ${id}`,
+						isMinor: false,
+						isConsented: true,
+						stats: profile.stats,
+						telemetry: profile.telemetry
+					};
+				}
+			}
+
+			// Fallback placeholder before profile is loaded, treated as safe default to protect potential minor PII
+			return {
+				id,
+				name: `Athlete #${id.substring(0, 4) || 'Anon'}`,
+				isMinor: true,
+				isConsented: false
+			};
+		})
+	);
+
+	isVotingOpen = $derived(this.votingActive);
 	activeSuperdrawPool = $derived(this.#campaignDoc?.totalPool ?? 0);
 	activeMvpStandings = $derived(
-		Object.entries(this.#sessionDoc?.mvpVoting?.results ?? {})
+		Object.entries(this.results)
 			.map(([uid, votes]) => ({ uid, votes }))
 			.sort((a, b) => b.votes - a.votes)
 	);
+
+	_maskName(fullName: string): string {
+		if (!fullName) return 'Athlete';
+		const parts = fullName.trim().split(/\s+/);
+		if (parts.length === 0) return 'Athlete';
+		if (parts.length === 1) return parts[0][0] + '.';
+		return `${parts[0]} ${parts[parts.length - 1][0]}.`;
+	}
+
+	_pseudonymizeStats(stats: any): any {
+		if (!stats) return undefined;
+		// Display only pseudonymized/safe aggregate metrics
+		return {
+			performanceTier: 'Verified',
+			matchesCount: stats.matchesCount || 0,
+			avgRating: stats.avgRating || '—'
+		};
+	}
+
+	_pseudonymizeTelemetry(telemetry: any): any {
+		if (!telemetry) return undefined;
+		// Strip absolute positioning/identifiable coordinates, keep aggregate activity density
+		return {
+			activityLevel: 'Active',
+			vettedDistanceMeters: telemetry.vettedDistanceMeters || 0
+		};
+	}
 
 	connect(sessionId: string) {
 		this.sessionId = sessionId;
@@ -27,32 +118,120 @@ export class BroadcastEngine {
 
 		this.#unsubs.push(
 			onSnapshot(doc(db, 'broadcast_sessions', sessionId), (snap) => {
-				if (snap.exists()) untrack(() => { this.#sessionDoc = snap.data() as BroadcastSession; });
+				if (snap.exists()) {
+					untrack(() => {
+						const data = snap.data() as BroadcastSession;
+						this.#sessionDoc = data;
+						this._syncCandidateProfiles(data.mvpVoting?.candidates ?? []);
+					});
+				}
 			})
 		);
 		this.#unsubs.push(
 			onSnapshot(query(collection(db, 'superdraw_campaigns'), where('campaignId', '==', sessionId), limit(1)), (snap) => {
-				if (!snap.empty) untrack(() => { this.#campaignDoc = snap.docs[0].data() as SuperdrawCampaign; });
+				if (!snap.empty) {
+					untrack(() => {
+						this.#campaignDoc = snap.docs[0].data() as SuperdrawCampaign;
+					});
+				}
 			})
 		);
+	}
+
+	_syncCandidateProfiles(candidateIds: string[]) {
+		if (!isFirestoreReady()) return;
+		const db = getActiveDb();
+		if (!db) return;
+
+		// Clean up subscriptions for candidates no longer active
+		Object.keys(this.#candidateUnsubs).forEach((uid) => {
+			if (!candidateIds.includes(uid)) {
+				this.#candidateUnsubs[uid]();
+				delete this.#candidateUnsubs[uid];
+			}
+		});
+
+		// Subscribe to new candidates' user profiles to dynamically load PII-safety metadata
+		candidateIds.forEach((uid) => {
+			if (!this.#candidateUnsubs[uid]) {
+				const userRef = doc(db, 'users', uid);
+				this.#candidateUnsubs[uid] = onSnapshot(userRef, (snap) => {
+					if (snap.exists()) {
+						untrack(() => {
+							this.#candidateProfiles[uid] = snap.data();
+						});
+					}
+				});
+			}
+		});
 	}
 
 	disconnect() {
 		this.#unsubs.forEach(u => u());
 		this.#unsubs = [];
+		Object.values(this.#candidateUnsubs).forEach(u => u());
+		this.#candidateUnsubs = {};
+		if (this.#batchTimeout) {
+			clearTimeout(this.#batchTimeout);
+			this.#batchTimeout = null;
+		}
 	}
 
-	async submitVote(candidatePlayerUid: string) {
-		if (!isFirestoreReady() || !authStore.user?.uid || !this.isVotingOpen) return false;
+	// Commit votes to Firestore via server-side 'writeBatch' transactions capped at 500 writes
+	// Consolidate rapid sequential votes into atomic batches to avoid reactivity loops.
+	async submitVote(candidatePlayerUid: string): Promise<boolean> {
+		if (!isFirestoreReady() || !authStore.user?.uid || !this.isVotingOpen) {
+			return false;
+		}
 		const db = getActiveDb();
 		if (!db) return false;
-		const batch = writeBatch(db);
-		const interRef = doc(db, 'broadcast_sessions', this.sessionId, 'broadcast_interactions', authStore.user.uid);
-		batch.set(interRef, {
-			userId: authStore.user.uid, interactionType: 'vote', payload: { candidatePlayerUid }, timestamp: new Date().toISOString()
-		} as BroadcastInteraction);
-		await batch.commit();
-		return true;
+
+		return new Promise<boolean>((resolve, reject) => {
+			this.#pendingVotes.push({ candidatePlayerUid, resolve, reject });
+			this._scheduleBatchCommit();
+		});
+	}
+
+	_scheduleBatchCommit() {
+		if (this.#batchTimeout) return;
+		this.#batchTimeout = setTimeout(async () => {
+			this.#batchTimeout = null;
+			const votesToCommit = [...this.#pendingVotes];
+			this.#pendingVotes = [];
+
+			if (votesToCommit.length === 0) return;
+
+			try {
+				const db = getActiveDb();
+				if (!db) {
+					votesToCommit.forEach(v => v.resolve(false));
+					return;
+				}
+
+				const batchSize = 500;
+				for (let i = 0; i < votesToCommit.length; i += batchSize) {
+					const chunk = votesToCommit.slice(i, i + batchSize);
+					const batch = writeBatch(db);
+
+					chunk.forEach((vote) => {
+						const interRef = doc(collection(db, `broadcast_sessions/${this.sessionId}/broadcast_interactions`));
+						batch.set(interRef, {
+							userId: authStore.user?.uid || 'anonymous',
+							interactionType: 'vote',
+							payload: { candidatePlayerUid: vote.candidatePlayerUid },
+							timestamp: new Date().toISOString()
+						} as BroadcastInteraction);
+					});
+
+					await batch.commit();
+				}
+
+				votesToCommit.forEach(v => v.resolve(true));
+			} catch (err) {
+				console.error('Failed to commit batched votes:', err);
+				votesToCommit.forEach(v => v.resolve(false));
+			}
+		}, 10);
 	}
 
 	async purchaseSuperdrawEntry(quantity: number) {

--- a/src/routes/(app)/fan/watch/tests/broadcastEngine.test.ts
+++ b/src/routes/(app)/fan/watch/tests/broadcastEngine.test.ts
@@ -21,8 +21,7 @@ vi.mock('firebase/firestore', async () => {
 		limit: vi.fn(),
 		where: vi.fn(),
 		onSnapshot: vi.fn((_, cb) => {
-			// Mock initial snapshot trigger if needed
-			return vi.fn(); // unsubscribe mock
+			return vi.fn();
 		}),
 		writeBatch: vi.fn(() => ({
 			set: vi.fn(),
@@ -61,12 +60,10 @@ describe('BroadcastEngine', () => {
 
 	it('Test 1: Rejects vote submission without authentic credentials', async () => {
 		vi.mocked(isFirestoreReady).mockReturnValue(true);
-		Object.assign(authStore, { user: null }); // Unauthenticated
+		Object.assign(authStore, { user: null });
 		vi.mocked(getActiveDb).mockReturnValue({} as any);
 
 		engine.connect('test-session');
-
-		// Setup mock state to pretend voting is active
 		Object.defineProperty(engine, 'isVotingOpen', { get: () => true, configurable: true });
 
 		const result = await engine.submitVote('player1');
@@ -96,7 +93,7 @@ describe('BroadcastEngine', () => {
 	});
 
 	it('Test 3: Asserts isFirestoreReady blocks data-fetching if unauthenticated', () => {
-		vi.mocked(isFirestoreReady).mockReturnValue(false); // Unauthenticated / Not Ready
+		vi.mocked(isFirestoreReady).mockReturnValue(false);
 
 		engine.connect('test-session');
 
@@ -122,7 +119,6 @@ describe('Epic 6: Live MVP Voting Batching and Minor Player PII Protection', () 
 			isAuthenticated: true
 		});
 
-		// Setup onSnapshot callback capture
 		vi.mocked(onSnapshot).mockImplementation((ref: any, cb: any) => {
 			const path = ref?.path || '';
 			if (path.includes('broadcast_sessions/')) {
@@ -132,7 +128,7 @@ describe('Epic 6: Live MVP Voting Batching and Minor Player PII Protection', () 
 				const uid = parts[parts.length - 1];
 				userCallbacks[uid] = cb;
 			}
-			return vi.fn(); // Unsubscribe mock
+			return vi.fn();
 		});
 	});
 
@@ -142,7 +138,6 @@ describe('Epic 6: Live MVP Voting Batching and Minor Player PII Protection', () 
 	});
 
 	it('should correctly batch rapid sequential votes into a single writeBatch', async () => {
-		// Mock voting to be open
 		const mockSessionData = {
 			sessionId: 'session_abc',
 			mvpVoting: {
@@ -152,7 +147,6 @@ describe('Epic 6: Live MVP Voting Batching and Minor Player PII Protection', () 
 			}
 		};
 
-		// Connect and trigger session document snapshot
 		engine.connect('session_abc');
 		expect(sessionCallback).toBeTypeOf('function');
 		sessionCallback({
@@ -160,10 +154,8 @@ describe('Epic 6: Live MVP Voting Batching and Minor Player PII Protection', () 
 			data: () => mockSessionData
 		});
 
-		// Verify voting state is active
 		expect(engine.isVotingOpen).toBe(true);
 
-		// Prepare mock writeBatch
 		const mockCommit = vi.fn().mockResolvedValue(undefined);
 		const mockSet = vi.fn();
 		vi.mocked(writeBatch).mockReturnValue({
@@ -171,20 +163,17 @@ describe('Epic 6: Live MVP Voting Batching and Minor Player PII Protection', () 
 			commit: mockCommit
 		} as any);
 
-		// Submit 3 votes in rapid succession
 		const p1 = engine.submitVote('player_1');
 		const p2 = engine.submitVote('player_2');
 		const p3 = engine.submitVote('player_1');
 
-		// Advance timer for batchTimeout (10ms)
 		await vi.runAllTimersAsync();
 
-		// Wait for resolutions
 		const results = await Promise.all([p1, p2, p3]);
 
 		expect(results).toEqual([true, true, true]);
-		expect(mockCommit).toHaveBeenCalledTimes(1); // Consolidated in 1 batch commit!
-		expect(mockSet).toHaveBeenCalledTimes(3); // 3 individual vote documents set
+		expect(mockCommit).toHaveBeenCalledTimes(1);
+		expect(mockSet).toHaveBeenCalledTimes(3);
 	});
 
 	it('should protect minor player PII by displaying pseudonymized metrics and names', () => {
@@ -203,8 +192,6 @@ describe('Epic 6: Live MVP Voting Batching and Minor Player PII Protection', () 
 			data: () => mockSessionData
 		});
 
-		// Trigger profile loads
-		// 1. Minor unconsented
 		userCallbacks['minor_unconsented_1']?.({
 			exists: () => true,
 			data: () => ({
@@ -217,7 +204,6 @@ describe('Epic 6: Live MVP Voting Batching and Minor Player PII Protection', () 
 			})
 		});
 
-		// 2. Minor consented
 		userCallbacks['minor_consented_2']?.({
 			exists: () => true,
 			data: () => ({
@@ -230,7 +216,6 @@ describe('Epic 6: Live MVP Voting Batching and Minor Player PII Protection', () 
 			})
 		});
 
-		// 3. Adult player
 		userCallbacks['adult_3']?.({
 			exists: () => true,
 			data: () => ({
@@ -243,28 +228,25 @@ describe('Epic 6: Live MVP Voting Batching and Minor Player PII Protection', () 
 		const list = engine.candidates;
 		expect(list).toHaveLength(3);
 
-		// Assertions for unconsented minor (PII completely pseudonymized and restricted)
 		const c1 = list.find(c => c.id === 'minor_unconsented_1');
 		expect(c1).toBeDefined();
 		expect(c1.isMinor).toBe(true);
 		expect(c1.isConsented).toBe(false);
-		expect(c1.name).toBe('Athlete #mino'); // Pseudonymized to first 4 chars of ID
-		expect(c1.stats.performanceTier).toBe('Verified'); // Fallback safe stats
-		expect(c1.stats.privatePii).toBeUndefined(); // Stripped private stats
+		expect(c1.name).toBe('Athlete #mino');
+		expect(c1.stats.performanceTier).toBe('Verified');
+		expect(c1.stats.privatePii).toBeUndefined();
 
-		// Assertions for consented minor (displays vetted player-card profiles and masked name)
 		const c2 = list.find(c => c.id === 'minor_consented_2');
 		expect(c2).toBeDefined();
 		expect(c2.isMinor).toBe(true);
 		expect(c2.isConsented).toBe(true);
-		expect(c2.name).toBe('Sarah C.'); // Masked name to protect minor athlete PII in live broadcasts
+		expect(c2.name).toBe('Sarah C.');
 		expect(c2.stats.performanceTier).toBe('Elite');
 
-		// Assertions for adult (displays fully)
 		const c3 = list.find(c => c.id === 'adult_3');
 		expect(c3).toBeDefined();
 		expect(c3.isMinor).toBe(false);
-		expect(c3.name).toBe('John Doe'); // Real name displayed safely
+		expect(c3.name).toBe('John Doe');
 		expect(c3.stats.performanceTier).toBe('Silver');
 	});
 });


### PR DESCRIPTION
This change implements the Svelte 5 state controller (BroadcastEngine.svelte.ts) and its tests for the interactive Fan OS stream overlay live MVP voting system. It includes Svelte 5 runes, sequential writeBatch transactions capped at 500 writes, untracked onSnapshot listeners to prevent infinite rendering loops, and strict COPPA 2.0 Broadcast Shield compliance for minor player PII protection.

Fixes #180

---
*PR created automatically by Jules for task [14349413366956663194](https://jules.google.com/task/14349413366956663194) started by @blueneekone*