### PR TITLE
Gate Recruiter Search behind Checkr Vetting

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -100,6 +100,7 @@ All data collection must pass through these legal gates before a user accesses t
 *   [x] **SafeSport Comms (Shadow CC):** Immutable server-side Firestore triggers that automatically intercept coach-to-player direct messages, resolve the minor's household, and CC the parent email mathematically preventing 1:1 adult/minor channels [cite: 758, 1191].
 *   [x] **The Car Ride Home Protocol (EQ):** Suppresses raw metric dashboards for 15 minutes post-match to protect beginner self-worth [cite: 758].
 *   [x] **Vetted Recruiter Engine:** Checkr API integration mandating National Criminal Database vetting before external scouts gain platform access to prospect data [cite: 758, 1168].
+*   [x] **Checkr API Recruiter Search Gate:** Strict `isRecruiterCleared` security gates and cursor pagination size constraints protecting minor athlete data from un-vetted scouts [cite: 756, 1062, 1068].
 
 ##### 🏟️ EPIC 6: FAN OS & BROADCAST MONETIZATION
 **Mission:** Turn every club into a media franchise, eliminating fundraising friction [cite: 759].

--- a/src/lib/compliance/tests/checkrRecruiterGate.test.ts
+++ b/src/lib/compliance/tests/checkrRecruiterGate.test.ts
@@ -1,0 +1,155 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { isRecruiterCleared } from '$lib/components/recruiter/RecruiterOnboardingEngine.svelte.js';
+import { render, fireEvent, waitFor } from '@testing-library/svelte';
+import RecruiterSearchEngine from '$lib/components/recruiter/RecruiterSearchEngine.svelte';
+import { getDocs } from 'firebase/firestore';
+
+// Setup basic mocks using Proxy to avoid top-level hoisting ReferenceErrors in Vitest
+let mockAuthenticated = false;
+let mockUserProfile: any = null;
+
+vi.mock('$lib/stores/auth/facade.svelte.js', () => ({
+	authStore: new Proxy({}, {
+		get: (_, prop) => {
+			if (prop === 'isAuthenticated') return mockAuthenticated;
+			if (prop === 'userProfile') return mockUserProfile;
+			return undefined;
+		}
+	})
+}));
+
+vi.mock('$app/environment', () => ({
+	browser: true
+}));
+
+vi.mock('$lib/firebase.js', () => ({
+	db: {}
+}));
+
+vi.mock('firebase/firestore', () => {
+	const dummyRef = { _delegate: {} };
+	return {
+		collection: vi.fn(() => dummyRef),
+		query: vi.fn(() => dummyRef),
+		where: vi.fn(() => dummyRef),
+		limit: vi.fn(() => dummyRef),
+		orderBy: vi.fn(() => dummyRef),
+		startAfter: vi.fn(() => dummyRef),
+		doc: vi.fn(() => dummyRef),
+		getDocs: vi.fn(() => ({
+			docs: [],
+			forEach: () => {}
+		})),
+		onSnapshot: vi.fn(() => () => {})
+	};
+});
+
+describe('Checkr Recruiter Gate - RecruiterOnboardingEngine & isRecruiterCleared', () => {
+	beforeEach(() => {
+		mockAuthenticated = false;
+		mockUserProfile = null;
+		vi.mocked(getDocs).mockClear();
+	});
+
+	it('returns false when the recruiter is not authenticated', () => {
+		mockAuthenticated = false;
+		mockUserProfile = { vettingStatus: 'cleared' };
+		expect(isRecruiterCleared()).toBe(false);
+	});
+
+	it('returns false when userProfile is null', () => {
+		mockAuthenticated = true;
+		mockUserProfile = null;
+		expect(isRecruiterCleared()).toBe(false);
+	});
+
+	it('returns false for pending accounts', () => {
+		mockAuthenticated = true;
+		mockUserProfile = { vettingStatus: 'pending' };
+		expect(isRecruiterCleared()).toBe(false);
+	});
+
+	it('returns false for consider accounts', () => {
+		mockAuthenticated = true;
+		mockUserProfile = { vettingStatus: 'consider' };
+		expect(isRecruiterCleared()).toBe(false);
+	});
+
+	it('returns false for suspended accounts', () => {
+		mockAuthenticated = true;
+		mockUserProfile = { vettingStatus: 'suspended' };
+		expect(isRecruiterCleared()).toBe(false);
+	});
+
+	it('returns false for flagged accounts', () => {
+		mockAuthenticated = true;
+		mockUserProfile = { vettingStatus: 'flagged' };
+		expect(isRecruiterCleared()).toBe(false);
+	});
+
+	it('returns true ONLY for explicitly cleared accounts', () => {
+		mockAuthenticated = true;
+		mockUserProfile = { vettingStatus: 'cleared' };
+		expect(isRecruiterCleared()).toBe(true);
+	});
+
+	it('returns true when status in clearance sub-object is clear/cleared', () => {
+		mockAuthenticated = true;
+		mockUserProfile = { clearance: { status: 'cleared' } };
+		expect(isRecruiterCleared()).toBe(true);
+
+		mockUserProfile = { clearance: { status: 'clear' } };
+		expect(isRecruiterCleared()).toBe(true);
+	});
+});
+
+describe('Checkr Recruiter Gate - RecruiterSearchEngine Search Query Lockout', () => {
+	beforeEach(() => {
+		mockAuthenticated = false;
+		mockUserProfile = null;
+		vi.mocked(getDocs).mockClear();
+	});
+
+	it('should return empty array and NOT execute firestore query for pending recruiter', async () => {
+		mockAuthenticated = true;
+		mockUserProfile = { vettingStatus: 'pending' };
+
+		render(RecruiterSearchEngine);
+
+		// The initial $effect triggers search automatically, so we can wait and assert it is not called.
+		await new Promise((r) => setTimeout(r, 100));
+		expect(getDocs).not.toHaveBeenCalled();
+	});
+
+	it('should return empty array and NOT execute firestore query for consider recruiter', async () => {
+		mockAuthenticated = true;
+		mockUserProfile = { vettingStatus: 'consider' };
+
+		render(RecruiterSearchEngine);
+
+		await new Promise((r) => setTimeout(r, 100));
+		expect(getDocs).not.toHaveBeenCalled();
+	});
+
+	it('should return empty array and NOT execute firestore query for suspended recruiter', async () => {
+		mockAuthenticated = true;
+		mockUserProfile = { vettingStatus: 'suspended' };
+
+		render(RecruiterSearchEngine);
+
+		await new Promise((r) => setTimeout(r, 100));
+		expect(getDocs).not.toHaveBeenCalled();
+	});
+
+	it('should successfully execute query ONLY when recruiter is explicitly cleared', async () => {
+		mockAuthenticated = true;
+		mockUserProfile = { vettingStatus: 'cleared' };
+
+		render(RecruiterSearchEngine);
+
+		await waitFor(() => {
+			expect(getDocs).toHaveBeenCalled();
+		});
+	});
+});

--- a/src/lib/components/recruiter/RecruiterOnboardingEngine.svelte.ts
+++ b/src/lib/components/recruiter/RecruiterOnboardingEngine.svelte.ts
@@ -1,0 +1,71 @@
+import { authStore } from '$lib/stores/auth/facade.svelte.js';
+import { db } from '$lib/firebase.js';
+import { doc, onSnapshot } from 'firebase/firestore';
+import { untrack } from 'svelte';
+
+export class RecruiterOnboardingEngine {
+	vettingStatus = $state<string>('pending');
+	loading = $state<boolean>(true);
+	error = $state<string>('');
+
+	constructor() {
+		this.subscribe();
+	}
+
+	subscribe() {
+		// Use Svelte 5 effect.root to manage reactive subscriptions
+		$effect.root(() => {
+			$effect(() => {
+				if (authStore.isLoading) return;
+				if (!authStore.isAuthenticated) {
+					this.loading = false;
+					return;
+				}
+
+				const uid = authStore.user?.uid;
+				if (!uid || !db) return;
+
+				this.loading = true;
+				// Real-time Firestore stream to poll Checkr background check status
+				const unsub = onSnapshot(
+					doc(db, 'recruiters', uid),
+					(snap) => {
+						untrack(() => {
+							if (snap.exists()) {
+								const data = snap.data();
+								this.vettingStatus = data?.vettingStatus || 'pending';
+							} else {
+								this.vettingStatus = (authStore.userProfile?.vettingStatus as string) || 'pending';
+							}
+							this.loading = false;
+						});
+					},
+					(err) => {
+						untrack(() => {
+							this.error = err.message || 'Failed to poll recruiter vetting status';
+							this.loading = false;
+						});
+					}
+				);
+
+				return () => unsub();
+			});
+		});
+	}
+
+	isRecruiterCleared(): boolean {
+		return isRecruiterCleared();
+	}
+}
+
+/**
+ * Returns true ONLY when Checkr status is explicitly 'cleared' or 'clear'.
+ */
+export function isRecruiterCleared(): boolean {
+	if (!authStore.isAuthenticated) return false;
+	const profile = authStore.userProfile;
+	if (!profile) return false;
+
+	const status = profile.vettingStatus || (profile.clearance?.status as string | undefined);
+	return status === 'cleared' || status === 'clear';
+}

--- a/src/lib/components/recruiter/RecruiterSearchEngine.svelte
+++ b/src/lib/components/recruiter/RecruiterSearchEngine.svelte
@@ -11,6 +11,7 @@
 		startAfter,
 		where,
 	} from 'firebase/firestore';
+	import { isRecruiterCleared } from './RecruiterOnboardingEngine.svelte.js';
 	import Modal from '$lib/components/Modal.svelte';
 	import ClubLogoMark from '$lib/components/ClubLogoMark.svelte';
 	import LevelProgressRing from '$lib/components/LevelProgressRing.svelte';
@@ -64,6 +65,10 @@
 
 	async function runSearch() {
 		if (!browser) return;
+		if (!isRecruiterCleared()) {
+			results = [];
+			return;
+		}
 		loading = true;
 		errorMsg = '';
 		results = [];
@@ -113,6 +118,17 @@
 			/** @type {typeof results} */
 			const rows = [];
 			snap.forEach((d) => rows.push({ id: d.id, ...(d.data() as Record<string, unknown>) }));
+
+			const size = new TextEncoder().encode(JSON.stringify(rows)).length;
+			if (size > 200 * 1024) {
+				console.warn('Search results exceeded 200KB payload limit');
+				errorMsg = 'Search payload limit exceeded (200KB max). Please narrow your filters.';
+				results = [];
+				hasMore = false;
+				lastDoc = null;
+				return;
+			}
+
 			lastDoc = snap.docs.length > 0 ? snap.docs[snap.docs.length - 1] : null;
 			hasMore = snap.docs.length === 20;
 			results = rows;
@@ -128,6 +144,10 @@
 
 	async function loadMore() {
 		if (!db || !authStore.isAuthenticated || !hasMore || loading) return;
+		if (!isRecruiterCleared()) {
+			results = [];
+			return;
+		}
 		loading = true;
 		const min = Math.max(1, Math.min(99, Math.floor(Number(minLevel) || 1)));
 		const col = collection(db, 'public_player_profiles');
@@ -147,7 +167,16 @@
 			const snap = await getDocs(q);
 			const rows = [];
 			snap.forEach((d) => rows.push({ id: d.id, ...(d.data() as Record<string, unknown>) }));
-			results = [...results, ...rows];
+
+			const combined = [...results, ...rows];
+			const size = new TextEncoder().encode(JSON.stringify(combined)).length;
+			if (size > 200 * 1024) {
+				console.warn('Cumulative search results exceeded 200KB payload limit');
+				hasMore = false;
+				return;
+			}
+
+			results = combined;
 			lastDoc = snap.docs.length > 0 ? snap.docs[snap.docs.length - 1] : null;
 			hasMore = snap.docs.length === 20;
 		} catch (e) {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
 		environment: 'node',
 		include: [
 			'src/**/__tests__/**/*.test.ts',
+			'src/lib/compliance/tests/**/*.test.ts',
 			'docs/**/__tests__/**/*.test.ts',
 			'scripts/**/__tests__/**/*.test.ts',
 		],


### PR DESCRIPTION
This submission implements the Checkr API Recruiter search lockout gates to secure minor athlete profiles from un-vetted scouts. 

Changes include:
1. Created RecruiterOnboardingEngine.svelte.ts to track Checkr verification status and expose isRecruiterCleared() helper.
2. Modified RecruiterSearchEngine.svelte to inject isRecruiterCleared() checks at search entry points, preventing non-cleared recruiters from issuing Firestore query read bombs.
3. Implemented robust cursor pagination byte-size limits of 200KB for Firestore queries.
4. Created comprehensive unit and integration tests inside src/lib/compliance/tests/checkrRecruiterGate.test.ts asserting correct behavior for both isRecruiterCleared() and RecruiterSearchEngine.
5. Successfully ran all tests with a 100% pass rate.
6. Updated MASTER ROADMAP.md to track Epic 5 security task completion.

Fixes #178

---
*PR created automatically by Jules for task [14387342215129025190](https://jules.google.com/task/14387342215129025190) started by @blueneekone*