### PR TITLE
feat: enforce single-use cryptographic federation invites

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -153,6 +153,9 @@ const b2bEnrollmentOps = require('./src/domains/b2bEnrollmentOps.js');
 exports.enrollIndependentDirector = b2bEnrollmentOps.enrollIndependentDirector;
 exports.enrollGovernedDirector = b2bEnrollmentOps.enrollGovernedDirector;
 
+const federationInvites = require('./lib/domains/federationInvites.js');
+exports.consumeFederationInvite = federationInvites.consumeFederationInvite;
+
 const ingestRoster = require("./ingestRoster.js");
 exports.ingestRoster = ingestRoster.ingestRoster;
 

--- a/functions/lib/domains/federationInvites.js
+++ b/functions/lib/domains/federationInvites.js
@@ -1,0 +1,99 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.consumeFederationInvite = void 0;
+const https_1 = require("firebase-functions/v2/https");
+const admin = __importStar(require("firebase-admin"));
+const crypto_1 = require("crypto");
+const db = () => admin.firestore();
+exports.consumeFederationInvite = (0, https_1.onCall)({ region: 'us-east1' }, async (request) => {
+    if (!request.auth) {
+        throw new https_1.HttpsError('unauthenticated', 'Must be signed in to consume federation invite.');
+    }
+    const uid = request.auth.uid;
+    const inviteToken = typeof request.data === 'string'
+        ? request.data
+        : (request.data?.inviteToken || '');
+    if (!inviteToken) {
+        throw new https_1.HttpsError('invalid-argument', 'Invite token is required.');
+    }
+    const snap = await db().collection('federation_invites').where('token', '==', inviteToken).get();
+    if (snap.empty) {
+        throw new https_1.HttpsError('not-found', 'Invite not found.');
+    }
+    const inviteDoc = snap.docs[0];
+    const inviteData = inviteDoc.data();
+    if (inviteData.is_used !== false) {
+        throw new https_1.HttpsError('failed-precondition', 'Invite is already used.');
+    }
+    const current_time = Date.now();
+    const expVal = inviteData.expiration_timestamp;
+    const expMs = (expVal && typeof expVal.toMillis === 'function')
+        ? expVal.toMillis()
+        : new Date(expVal).getTime();
+    if (current_time >= expMs) {
+        throw new https_1.HttpsError('failed-precondition', 'Invite is expired.');
+    }
+    const masterTenantId = inviteData.tenantId || inviteData.masterTenantId;
+    const newClubId = `club_${(0, crypto_1.randomBytes)(8).toString('hex')}`;
+    const batch = db().batch();
+    batch.update(inviteDoc.ref, {
+        is_used: true,
+        used_by: uid,
+        used_at: admin.firestore.FieldValue.serverTimestamp(),
+    });
+    batch.set(db().collection('users').doc(uid), {
+        uid,
+        role: 'director',
+        type: 'governed',
+        clubId: newClubId,
+        tenantId: masterTenantId,
+        createdAt: admin.firestore.FieldValue.serverTimestamp(),
+    }, { merge: true });
+    batch.set(db().collection('b2b_enrollments').doc(uid), {
+        uid,
+        tenantId: masterTenantId,
+        clubId: newClubId,
+        type: 'governed',
+        inviteToken,
+        enrolledAt: admin.firestore.FieldValue.serverTimestamp(),
+    });
+    await batch.commit();
+    return {
+        success: true,
+        tenantId: masterTenantId,
+        clubId: newClubId,
+    };
+});

--- a/functions/src/__tests__/federationInvites.test.ts
+++ b/functions/src/__tests__/federationInvites.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as admin from 'firebase-admin';
+
+// Define mock functions for batch operations and queries
+const mockBatchUpdate = vi.fn();
+const mockBatchSet = vi.fn();
+const mockBatchCommit = vi.fn();
+
+const mockBatch = {
+  update: mockBatchUpdate,
+  set: mockBatchSet,
+  commit: mockBatchCommit,
+};
+
+const mockGet = vi.fn();
+
+const mockCollection = vi.fn().mockImplementation((colName) => {
+  return {
+    doc: (docId: string) => ({
+      ref: { id: docId, path: `${colName}/${docId}` },
+      get: mockGet,
+    }),
+    where: vi.fn().mockImplementation((field, op, value) => {
+      return {
+        get: mockGet,
+      };
+    }),
+  };
+});
+
+const mockDb = {
+  collection: mockCollection,
+  batch: () => mockBatch,
+};
+
+// Mock firebase-admin before importing consumeFederationInvite
+vi.mock('firebase-admin', () => {
+  return {
+    firestore: Object.assign(
+      () => mockDb,
+      {
+        FieldValue: {
+          serverTimestamp: () => 'MOCK_SERVER_TIMESTAMP',
+        },
+      }
+    ),
+  };
+});
+
+// Mock firebase-functions v2 https module
+vi.mock('firebase-functions/v2/https', () => {
+  return {
+    onCall: (config: any, handler: any) => {
+      return handler || config;
+    },
+    HttpsError: class HttpsError extends Error {
+      constructor(public code: string, message: string) {
+        super(message);
+      }
+    },
+  };
+});
+
+// Import the callable function
+import { consumeFederationInvite } from '../domains/federationInvites';
+
+describe('consumeFederationInvite Secure Gating & Auto-Nesting', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should reject with HttpsError unauthenticated if auth is missing', async () => {
+    const context = {
+      data: { inviteToken: 'token_123' },
+    };
+
+    await expect(consumeFederationInvite(context as any)).rejects.toThrowError(/Must be signed in/);
+    expect(mockBatchCommit).not.toHaveBeenCalled();
+  });
+
+  it('should reject with HttpsError invalid-argument if inviteToken is missing', async () => {
+    const context = {
+      auth: { uid: 'user_123' },
+      data: {},
+    };
+
+    await expect(consumeFederationInvite(context as any)).rejects.toThrowError(/Invite token is required/);
+    expect(mockBatchCommit).not.toHaveBeenCalled();
+  });
+
+  it('should reject with HttpsError not-found if token does not exist', async () => {
+    mockGet.mockResolvedValue({
+      empty: true,
+      docs: [],
+    });
+
+    const context = {
+      auth: { uid: 'user_123' },
+      data: { inviteToken: 'nonexistent_token' },
+    };
+
+    await expect(consumeFederationInvite(context as any)).rejects.toThrowError(/Invite not found/);
+    expect(mockBatchCommit).not.toHaveBeenCalled();
+  });
+
+  it('should reject with HttpsError if invite is already used', async () => {
+    mockGet.mockResolvedValue({
+      empty: false,
+      docs: [
+        {
+          ref: { id: 'invite_doc_id', path: 'federation_invites/invite_doc_id' },
+          data: () => ({
+            token: 'used_token_123',
+            is_used: true,
+            expiration_timestamp: {
+              toMillis: () => Date.now() + 100000,
+            },
+            tenantId: 'comm_tenant_abc',
+          }),
+        },
+      ],
+    });
+
+    const context = {
+      auth: { uid: 'user_123' },
+      data: { inviteToken: 'used_token_123' },
+    };
+
+    await expect(consumeFederationInvite(context as any)).rejects.toThrowError(/already used/);
+    expect(mockBatchCommit).not.toHaveBeenCalled();
+  });
+
+  it('should reject with HttpsError if invite is expired', async () => {
+    mockGet.mockResolvedValue({
+      empty: false,
+      docs: [
+        {
+          ref: { id: 'invite_doc_id', path: 'federation_invites/invite_doc_id' },
+          data: () => ({
+            token: 'expired_token_123',
+            is_used: false,
+            expiration_timestamp: {
+              toMillis: () => Date.now() - 100000, // past expiration
+            },
+            tenantId: 'comm_tenant_abc',
+          }),
+        },
+      ],
+    });
+
+    const context = {
+      auth: { uid: 'user_123' },
+      data: { inviteToken: 'expired_token_123' },
+    };
+
+    await expect(consumeFederationInvite(context as any)).rejects.toThrowError(/expired/);
+    expect(mockBatchCommit).not.toHaveBeenCalled();
+  });
+
+  it('should consume an active, valid token, mark it used, and nest new clubId under Commissioner tenantId', async () => {
+    const mockInviteToken = 'valid_token_123';
+    const mockMasterTenantId = 'commissioner_tenant_abc';
+
+    mockGet.mockResolvedValue({
+      empty: false,
+      docs: [
+        {
+          ref: { id: 'invite_doc_id', path: 'federation_invites/invite_doc_id' },
+          data: () => ({
+            token: mockInviteToken,
+            is_used: false,
+            expiration_timestamp: {
+              toMillis: () => Date.now() + 100000, // active
+            },
+            tenantId: mockMasterTenantId,
+          }),
+        },
+      ],
+    });
+
+    const context = {
+      auth: { uid: 'new_governed_director_uid' },
+      data: { inviteToken: mockInviteToken },
+    };
+
+    const res = await consumeFederationInvite(context as any);
+
+    expect(res.success).toBe(true);
+    expect(res.tenantId).toBe(mockMasterTenantId);
+    expect(res.clubId).toBeDefined();
+    expect(res.clubId.startsWith('club_')).toBe(true);
+
+    // Assert that the transaction atomically marks the token as used
+    expect(mockBatchUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'invite_doc_id' }),
+      expect.objectContaining({
+        is_used: true,
+        used_by: 'new_governed_director_uid',
+      })
+    );
+
+    // Assert that the transaction atomically creates the new Governed Director profile,
+    // nesting the new clubId directly under the Commissioner's master tenantId
+    expect(mockBatchSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ref: expect.objectContaining({ path: 'users/new_governed_director_uid' })
+      }),
+      expect.objectContaining({
+        uid: 'new_governed_director_uid',
+        role: 'director',
+        type: 'governed',
+        tenantId: mockMasterTenantId,
+        clubId: res.clubId,
+      }),
+      { merge: true }
+    );
+
+    expect(mockBatchSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ref: expect.objectContaining({ path: 'b2b_enrollments/new_governed_director_uid' })
+      }),
+      expect.objectContaining({
+        uid: 'new_governed_director_uid',
+        type: 'governed',
+        tenantId: mockMasterTenantId,
+        clubId: res.clubId,
+        inviteToken: mockInviteToken,
+      })
+    );
+
+    expect(mockBatchCommit).toHaveBeenCalled();
+  });
+});

--- a/functions/src/domains/federationInvites.ts
+++ b/functions/src/domains/federationInvites.ts
@@ -1,0 +1,78 @@
+import { onCall, HttpsError } from 'firebase-functions/v2/https';
+import * as admin from 'firebase-admin';
+import { randomBytes } from 'crypto';
+
+const db = () => admin.firestore();
+
+export const consumeFederationInvite = onCall({ region: 'us-east1' }, async (request) => {
+  if (!request.auth) {
+    throw new HttpsError('unauthenticated', 'Must be signed in to consume federation invite.');
+  }
+
+  const uid = request.auth.uid;
+  const inviteToken = typeof request.data === 'string'
+    ? request.data
+    : (request.data?.inviteToken || '');
+
+  if (!inviteToken) {
+    throw new HttpsError('invalid-argument', 'Invite token is required.');
+  }
+
+  const snap = await db().collection('federation_invites').where('token', '==', inviteToken).get();
+  if (snap.empty) {
+    throw new HttpsError('not-found', 'Invite not found.');
+  }
+
+  const inviteDoc = snap.docs[0];
+  const inviteData = inviteDoc.data();
+
+  if (inviteData.is_used !== false) {
+    throw new HttpsError('failed-precondition', 'Invite is already used.');
+  }
+
+  const current_time = Date.now();
+  const expVal = inviteData.expiration_timestamp;
+  const expMs = (expVal && typeof expVal.toMillis === 'function')
+    ? expVal.toMillis()
+    : new Date(expVal).getTime();
+
+  if (current_time >= expMs) {
+    throw new HttpsError('failed-precondition', 'Invite is expired.');
+  }
+
+  const masterTenantId = inviteData.tenantId || inviteData.masterTenantId;
+  const newClubId = `club_${randomBytes(8).toString('hex')}`;
+
+  const batch = db().batch();
+  batch.update(inviteDoc.ref, {
+    is_used: true,
+    used_by: uid,
+    used_at: admin.firestore.FieldValue.serverTimestamp(),
+  });
+
+  batch.set(db().collection('users').doc(uid), {
+    uid,
+    role: 'director',
+    type: 'governed',
+    clubId: newClubId,
+    tenantId: masterTenantId,
+    createdAt: admin.firestore.FieldValue.serverTimestamp(),
+  }, { merge: true });
+
+  batch.set(db().collection('b2b_enrollments').doc(uid), {
+    uid,
+    tenantId: masterTenantId,
+    clubId: newClubId,
+    type: 'governed',
+    inviteToken,
+    enrolledAt: admin.firestore.FieldValue.serverTimestamp(),
+  });
+
+  await batch.commit();
+
+  return {
+    success: true,
+    tenantId: masterTenantId,
+    clubId: newClubId,
+  };
+});

--- a/functions/tsconfig.grit.json
+++ b/functions/tsconfig.grit.json
@@ -11,6 +11,6 @@
     "declaration": false,
     "allowJs": true
   },
-  "include": ["src/grit.ts"],
+  "include": ["src/grit.ts", "src/domains/federationInvites.ts"],
   "exclude": ["src/**/*.test.js", "src/grit.js"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
 			'src/routes/**/tests/**/*.test.ts',
 			'docs/**/__tests__/**/*.test.ts',
 			'scripts/**/__tests__/**/*.test.ts',
+			'functions/src/__tests__/**/*.test.ts',
 		],
 		alias: {
 			$lib: resolve(__dirname, 'src/lib'),


### PR DESCRIPTION
Implemented the secure single-use cryptographic federation invite consumption and auto-nesting gating pipeline. Created the consumeFederationInvite secure callable cloud function with rigorous gating checks and atomic batch operations to preserve cell-isolation under the Commissioner's tenant ID, complete with solid unit tests.

Fixes #203

---
*PR created automatically by Jules for task [4314438272323499542](https://jules.google.com/task/4314438272323499542) started by @blueneekone*