### PR TITLE
🔒 Fix DOM XSS vulnerability in legacy stats calendar

### DIFF
--- a/legacy/modules/stats.js
+++ b/legacy/modules/stats.js
@@ -46,15 +46,32 @@ export const renderCalendar = (logs) => {
                 setText("dayModalDate", dStr);
                 const content = document.getElementById("dayModalContent");
                 if(content) {
-                    content.innerHTML = daily.map(l => {
+                    content.innerHTML = "";
+                    daily.forEach(l => {
                         const wName = l.name || l.drillSummary || l.drill || l.type || 'Workout';
                         const pName = l.player || l.playerName || 'Unknown Player';
                         const mins = l.minutes || l.time || 0;
-                        return `<div style="border-bottom:1px solid #eee; padding:10px 5px;">
-                            <b style="color:var(--aggie-blue);">${pName}</b><br>
-                            <span style="font-size:12px; color:#64748b;">${wName} (${mins}m)</span>
-                        </div>`;
-                    }).join("");
+
+                        const entryDiv = document.createElement("div");
+                        entryDiv.style.borderBottom = "1px solid #eee";
+                        entryDiv.style.padding = "10px 5px";
+
+                        const b = document.createElement("b");
+                        b.style.color = "var(--aggie-blue)";
+                        b.textContent = pName;
+
+                        const br = document.createElement("br");
+
+                        const span = document.createElement("span");
+                        span.style.fontSize = "12px";
+                        span.style.color = "#64748b";
+                        span.textContent = `${wName} (${mins}m)`;
+
+                        entryDiv.appendChild(b);
+                        entryDiv.appendChild(br);
+                        entryDiv.appendChild(span);
+                        content.appendChild(entryDiv);
+                    });
                 }
                 
                 const modal = document.getElementById("dayModal");


### PR DESCRIPTION
🎯 **What:** 
A DOM-based Cross-Site Scripting (XSS) vulnerability in the legacy stats module (`legacy/modules/stats.js`) caused by unsanitized input (`playerName`, `workoutName`) being parsed and rendered via `.innerHTML`.

⚠️ **Risk:** 
If left unfixed, an attacker could inject arbitrary malicious JavaScript into the `playerName` or `workoutName` fields. When this data is rendered in the stats calendar modal via `innerHTML`, the malicious script would execute in the context of the user's browser, potentially leading to session hijacking, data exfiltration, or further compromise of user accounts.

🛡️ **Solution:** 
Replaced the dangerous `.innerHTML` assignment with safe DOM manipulation techniques. The code now iterates over the logs, creates standard elements (`div`, `b`, `span`) via `document.createElement`, applies styles safely, and assigns user data directly to `.textContent`. This treats the data strictly as text, ensuring that any HTML tags injected by a malicious user are safely encoded and rendered as literals instead of being parsed as executable code.

---
*PR created automatically by Jules for task [869920419205848489](https://jules.google.com/task/869920419205848489) started by @blueneekone*