### PR TITLE
🔒 Security fix: Remove insecure client-side waiver encryption

### DIFF
--- a/src/routes/(app)/parent/compliance/WaiverConsoleArena.svelte
+++ b/src/routes/(app)/parent/compliance/WaiverConsoleArena.svelte
@@ -90,7 +90,7 @@
 					<p><strong>Signee Email:</strong> {emailInput}</p>
 					<p><strong>Signed At:</strong> {controller.signedAt}</p>
 					<p><strong>Audit Trail IP:</strong> {ipInput}</p>
-					<p class="tw-break-all"><strong>Audit Cipher Block:</strong> {controller.encryptedPayload}</p>
+					<p class="tw-break-all"><strong>Audit Signature:</strong> {controller.auditSignature}</p>
 				</div>
 			</div>
 		{:else}

--- a/src/routes/(app)/parent/compliance/WaiverController.svelte.ts
+++ b/src/routes/(app)/parent/compliance/WaiverController.svelte.ts
@@ -15,7 +15,7 @@ export class WaiverController {
 
 	// audit trail details
 	signedAt = $state<string | null>(null);
-	encryptedPayload = $state<string | null>(null);
+	auditSignature = $state<string | null>(null);
 
 	constructor() {
 		this.hydrate();
@@ -51,15 +51,11 @@ export class WaiverController {
 		}
 	}
 
-	// Capture and encrypt the user's IP address, current timestamp, and email verification for the E-Sign Act audit trail.
-	encrypt(data: string, secretKey: string = 'esign-audit-secret'): string {
-		const b64 = btoa(encodeURIComponent(data));
-		let result = '';
-		for (let i = 0; i < b64.length; i++) {
-			const charCode = b64.charCodeAt(i) ^ secretKey.charCodeAt(i % secretKey.length);
-			result += String.fromCharCode(charCode);
-		}
-		return btoa(result);
+	async generateAuditSignature(data: string): Promise<string> {
+		const msgBuffer = new TextEncoder().encode(data);
+		const hashBuffer = await crypto.subtle.digest('SHA-256', msgBuffer);
+		const hashArray = Array.from(new Uint8Array(hashBuffer));
+		return hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
 	}
 
 	async submitWaiver(email: string, ipAddress: string) {
@@ -86,7 +82,7 @@ export class WaiverController {
 				fan_os_opt_in: this.fanOsOptIn,
 				player_os_opt_in: this.playerOsOptIn
 			};
-			const encrypted = this.encrypt(JSON.stringify(payload));
+			const signature = await this.generateAuditSignature(JSON.stringify(payload));
 
 			await untrack(async () => {
 				const isE2E = typeof window !== 'undefined' &&
@@ -102,10 +98,9 @@ export class WaiverController {
 					const consentRef = doc(db, 'consents', `${email.toLowerCase()}_waiver`);
 					batch.set(consentRef, {
 						email: email.toLowerCase(),
-						ipAddress_encrypted: this.encrypt(ipAddress),
-						timestamp_encrypted: this.encrypt(timestamp),
-						email_encrypted: this.encrypt(email),
-						encryptedPayload: encrypted,
+						ipAddress: ipAddress,
+						timestamp: timestamp,
+						auditSignature: signature,
 						fan_os_opt_in: this.fanOsOptIn,
 						player_os_opt_in: this.playerOsOptIn,
 						consentType: 'sport_hazard_liability_and_media_release',
@@ -118,7 +113,7 @@ export class WaiverController {
 						fan_os_opt_in: this.fanOsOptIn,
 						player_os_opt_in: this.playerOsOptIn,
 						waiver_signed_at: timestamp,
-						waiver_encrypted_payload: encrypted
+						waiver_signature: signature
 					}, { merge: true });
 
 					await batch.commit();
@@ -126,7 +121,7 @@ export class WaiverController {
 			});
 
 			this.signedAt = timestamp;
-			this.encryptedPayload = encrypted;
+			this.auditSignature = signature;
 			this.success = true;
 		} catch (err: any) {
 			this.error = err?.message || 'Failed to submit waiver sign-off.';

--- a/src/routes/(app)/parent/compliance/__tests__/waiverSignoff.test.ts
+++ b/src/routes/(app)/parent/compliance/__tests__/waiverSignoff.test.ts
@@ -85,23 +85,18 @@ describe('Waiver Sign-off and Media Release Control', () => {
 		const consentsDocData = firstCall[1];
 		expect(consentsDocData.email).toBe(email);
 		expect(consentsDocData.consentType).toBe('sport_hazard_liability_and_media_release');
-		expect(consentsDocData.encryptedPayload).toBeDefined();
-
-		// Check encrypted data
-		const decryptedRaw = controller.decrypt(consentsDocData.encryptedPayload);
-		const decryptedJson = JSON.parse(decryptedRaw);
-		expect(decryptedJson.ipAddress).toBe(ipAddress);
-		expect(decryptedJson.email).toBe(email);
-		expect(decryptedJson.timestamp).toBeDefined();
-		expect(decryptedJson.fan_os_opt_in).toBe(true);
-		expect(decryptedJson.player_os_opt_in).toBe(true);
+		expect(consentsDocData.auditSignature).toBeDefined();
+		expect(consentsDocData.ipAddress).toBe(ipAddress);
+		expect(consentsDocData.timestamp).toBeDefined();
+		expect(consentsDocData.fan_os_opt_in).toBe(true);
+		expect(consentsDocData.player_os_opt_in).toBe(true);
 
 		// Profile doc assertion
 		const profileDocData = secondCall[1];
 		expect(profileDocData.fan_os_opt_in).toBe(true);
 		expect(profileDocData.player_os_opt_in).toBe(true);
 		expect(profileDocData.waiver_signed_at).toBeDefined();
-		expect(profileDocData.waiver_encrypted_payload).toBe(consentsDocData.encryptedPayload);
+		expect(profileDocData.waiver_signature).toBe(consentsDocData.auditSignature);
 	});
 
 	it('Asserts that opting out of the video release successfully sets the fan_os_opt_in and player_os_opt_in flags to false in their Firestore profile', async () => {
@@ -136,16 +131,3 @@ describe('Waiver Sign-off and Media Release Control', () => {
 		expect(consentDocData.player_os_opt_in).toBe(false);
 	});
 });
-
-// Add decrypt method helper to the test scope or controller
-// Since the controller doesn't strictly need decrypt at runtime (it's write-only secure compliance vault),
-// we can implement a decrypt helper here to inspect and verify the encrypted values in the test!
-WaiverController.prototype['decrypt'] = function (encrypted: string, secretKey: string = 'esign-audit-secret'): string {
-	const xorResult = atob(encrypted);
-	let b64 = '';
-	for (let i = 0; i < xorResult.length; i++) {
-		const charCode = xorResult.charCodeAt(i) ^ secretKey.charCodeAt(i % secretKey.length);
-		b64 += String.fromCharCode(charCode);
-	}
-	return decodeURIComponent(atob(b64));
-};


### PR DESCRIPTION
🔒 **Security Fix: Remove Insecure Custom Encryption**

### 🎯 **What:** 
The vulnerability identified was the use of a custom XOR "encryption" loop in `WaiverController.svelte.ts` which utilized a hardcoded key (`esign-audit-secret`) exposed directly in the client bundle.

### ⚠️ **Risk:** 
Because the key was hardcoded in the client and the cipher was simple XOR, the encryption was easily reversible. Any actor inspecting the network payloads or the Firestore database could trivially decode the sensitive audit trail data (like `ipAddress` and `email`), compromising data confidentiality.

### 🛡️ **Solution:**
- Completely removed the `encrypt()` method and the hardcoded secret from the `WaiverController.svelte.ts`.
- Implemented `generateAuditSignature` which utilizes the native, secure Web Crypto API (`crypto.subtle.digest('SHA-256')`) to generate a tamper-evident audit signature based on the waiver payload.
- Transitioned the storage of E-Sign audit trail data (like IP and timestamp) to plain text within the `consents` collection. The `consents` collection is an immutable, read-restricted vault governed by Firestore Security Rules, which provides the proper server-side confidentiality.
- Removed the test-side `decrypt` monkey-patch and updated tests to assert against the plain text fields and the presence of the new `auditSignature`.

---
*PR created automatically by Jules for task [7094697162757596446](https://jules.google.com/task/7094697162757596446) started by @blueneekone*