### PR TITLE
🧪 test: add phoneUtils toE164 tests

### DIFF
--- a/src/lib/utils/__tests__/phoneUtils.test.ts
+++ b/src/lib/utils/__tests__/phoneUtils.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { toE164, isValidPhone, prefixAndNationalToE164 } from '../phoneUtils';
+
+describe('phoneUtils', () => {
+	describe('toE164', () => {
+		it('formats a US national number correctly when US country code is provided', () => {
+			expect(toE164('(202) 555-0123', 'US')).toBe('+12025550123');
+		});
+
+		it('formats an international number with a plus prefix without a country code', () => {
+			expect(toE164('+44 20 7946 0958')).toBe('+442079460958');
+		});
+
+		it('returns null for an invalid string', () => {
+			expect(toE164('not-a-number', 'US')).toBeNull();
+		});
+
+		it('returns null for an incomplete phone number', () => {
+			expect(toE164('123', 'US')).toBeNull();
+		});
+
+		it('returns null when empty string is provided', () => {
+			expect(toE164('')).toBeNull();
+		});
+
+		it('returns null for a national number when country code is missing', () => {
+			expect(toE164('(202) 555-0123')).toBeNull();
+		});
+
+		it('handles numbers with extra spaces or dashes', () => {
+			expect(toE164('202- 555 - 0123', 'US')).toBe('+12025550123');
+		});
+
+		it('handles valid UK number when GB country code is provided', () => {
+			expect(toE164('020 7946 0958', 'GB')).toBe('+442079460958');
+		});
+	});
+
+	describe('isValidPhone', () => {
+		it('returns true for a valid number', () => {
+			expect(isValidPhone('(202) 555-0123', 'US')).toBe(true);
+		});
+
+		it('returns false for an invalid number', () => {
+			expect(isValidPhone('not-a-number', 'US')).toBe(false);
+		});
+	});
+
+	describe('prefixAndNationalToE164', () => {
+		it('formats a number with a known prefix', () => {
+			expect(prefixAndNationalToE164('+1', '(202) 555-0123')).toBe('+12025550123');
+		});
+
+		it('formats a number with a known prefix and no formatting', () => {
+			expect(prefixAndNationalToE164('+44', '2079460958')).toBe('+442079460958');
+		});
+
+		it('returns null for a known prefix but invalid national number', () => {
+			expect(prefixAndNationalToE164('+1', '123')).toBeNull();
+		});
+
+		it('returns valid number for prefix even if prefix is not in the dictionary', () => {
+			expect(prefixAndNationalToE164('+358', '40 123 4567')).toBe('+358401234567');
+		});
+	});
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The utility functions in `src/lib/utils/phoneUtils.ts` (specifically `toE164`, `isValidPhone`, and `prefixAndNationalToE164`) were completely untested. These are pure, critical utility functions that format strings into E.164 phone numbers.

📊 **Coverage:** What scenarios are now tested
- Formatting valid US numbers with `toE164`.
- Formatting valid international numbers with a '+' prefix.
- Rejecting invalid strings, empty strings, and incomplete numbers.
- Handling numbers with excessive spacing/dashes.
- Using `isValidPhone` to validate numbers correctly.
- Converting a known prefix and a national number into a proper E.164 format with `prefixAndNationalToE164`.

✨ **Result:** The improvement in test coverage
The code now has a full test suite verifying that phone string parsing and formatting behaves correctly across a wide variety of happy paths and edge cases, acting as a safety net against future refactoring bugs.

---
*PR created automatically by Jules for task [3237195218688221847](https://jules.google.com/task/3237195218688221847) started by @blueneekone*