### PR TITLE
Fix: Update product preview image on marketing page

### DIFF
--- a/src/routes/(marketing)/+page.svelte
+++ b/src/routes/(marketing)/+page.svelte
@@ -110,7 +110,7 @@
 			<div class="tw-absolute tw-inset-0 tw-bg-gradient-to-tr tw-from-[#000000] tw-to-transparent tw-z-10 tw-pointer-events-none tw-transition-opacity tw-duration-700 group-hover:tw-opacity-30"></div>
 			<!-- Generated product preview -->
 			<div class="tw-w-full tw-h-full tw-flex tw-items-center tw-justify-center tw-bg-[#000000] tw-transition-transform tw-duration-700 group-hover:tw-scale-[1.02]">
-				<img src="https://images.unsplash.com/photo-1518605368461-1e1e38ce81b5?ixlib=rb-4.0.3&auto=format&fit=crop&w=1280&q=80" alt="Product Preview" class="tw-w-full tw-h-full tw-object-cover tw-opacity-80" />
+				<img src="/nexus-command-preview.png" alt="Product Preview" class="tw-w-full tw-h-full tw-object-cover tw-opacity-80" />
 			</div>
 			<!-- Scanline overlay -->
 			<div class="tw-absolute tw-inset-0 tw-z-10 tw-pointer-events-none" style="opacity: 0.03; background: repeating-linear-gradient(0deg, transparent, transparent 3px, #fff 3px, #fff 4px);"></div>


### PR DESCRIPTION
Replaces the Unsplash placeholder image with the `nexus-command-preview.png` product image on the marketing landing page. This resolves the `FIX #1: Product preview image (no more placehold.co)` comment.

---
*PR created automatically by Jules for task [11757519567682249434](https://jules.google.com/task/11757519567682249434) started by @blueneekone*