### PR TITLE
Fix: Update marketing page to use asymmetric bento grid

### DIFF
--- a/src/routes/(marketing)/+page.svelte
+++ b/src/routes/(marketing)/+page.svelte
@@ -19,7 +19,7 @@
 			body: 'Gamified Skill Trees, XP progression, Vanguard Prism radars, and video trial uploads driving intrinsic motivation and unyielding athlete engagement.',
 			href: '/player',
 			hoverColor: '#14b8a6',
-			cols: 'md:tw-col-span-4',
+			cols: 'md:tw-col-span-5',
 			bento: 'player'
 		},
 		{
@@ -43,7 +43,7 @@
 			body: 'COPPA 2.0 WebAuthn biometric gating, SafeSport Shadow CC routing, and the Car Ride Home emotional safety protocol.',
 			href: '/parent',
 			hoverColor: '#14b8a6',
-			cols: 'md:tw-col-span-4',
+			cols: 'md:tw-col-span-3',
 			bento: 'parent'
 		}
 	];
@@ -131,7 +131,6 @@
 	</main>
 
 	<!-- ═══ ECOSYSTEM — Asymmetric 12-col Bento Grid ═══ -->
-	<!-- FIX #4: Replace tw-grid-cols-3 with asymmetric 12-col weighting -->
 	<section class="tw-max-w-7xl tw-mx-auto tw-w-full tw-px-6 tw-py-24">
 		<div class="tw-flex tw-flex-col tw-items-center tw-text-center tw-mb-16">
 			<span class="tw-font-mono tw-text-xs tw-text-[#f59e0b] tw-tracking-widest tw-mb-4" style="font-family: 'Geist Mono', monospace;">SYS.ECOSYSTEM</span>
@@ -139,7 +138,7 @@
 			<p class="tw-text-[#D4D4D8] tw-mt-4 tw-max-w-2xl" style="font-family: 'Switzer', sans-serif;">Complete operational parity across your club's most critical personas.</p>
 		</div>
 
-		<!-- Symmetric: 4 / 4 / 4 column weighting -->
+		<!-- Asymmetric: 5 / 4 / 3 column weighting -->
 		<div class="tw-grid tw-grid-cols-1 md:tw-grid-cols-12 tw-gap-4 md:tw-gap-6">
 			{#each features as feat}
 				<div data-bento={feat.bento} class="tw-col-span-1 {feat.cols} tw-transition-all tw-duration-300 tw-h-full bento-wrapper">

--- a/src/routes/(marketing)/__tests__/marketingLanding.test.ts
+++ b/src/routes/(marketing)/__tests__/marketingLanding.test.ts
@@ -2,13 +2,11 @@ import { describe, it, expect } from 'vitest';
 import PageSource from '../+page.svelte?raw';
 
 describe('CDO Protocol: Marketing Landing Page Audit', () => {
-	it('MUST enforce the strict 12-column symmetric Bento Grid (4/4/4)', () => {
-		// The `features` array should define the equal col-spans.
+	it('MUST enforce the strict 12-column asymmetric Bento Grid (5/4/3)', () => {
+		// The `features` array should define the asymmetric col-spans.
+		expect(PageSource).toContain("cols: 'md:tw-col-span-5'");
 		expect(PageSource).toContain("cols: 'md:tw-col-span-4'");
-		
-		// It should contain three symmetrical 4-columns
-		const count4Col = (PageSource.match(/md:tw-col-span-4/g) || []).length;
-		expect(count4Col).toBe(3);
+		expect(PageSource).toContain("cols: 'md:tw-col-span-3'");
 	});
 
 	it('MUST absolutely eradicate unauthorized dark hex codes (#0B0F19, #1e293b)', () => {


### PR DESCRIPTION
Updates the marketing page features grid to use an asymmetric 12-column layout (5/4/3 column weighting instead of 4/4/4), fixing the layout comment `FIX #4`. It also updates the unit tests checking for this requirement.

---
*PR created automatically by Jules for task [12835384416271070335](https://jules.google.com/task/12835384416271070335) started by @blueneekone*