### PR TITLE
🔒 Fix authentication token exposure in audit-login URL

### DIFF
--- a/src/routes/audit-login/+page.svelte
+++ b/src/routes/audit-login/+page.svelte
@@ -1,29 +1,18 @@
 <script lang="ts">
-  import { browser } from '$app/environment';
-  import { auth } from '$lib/firebase.js';
-  import { signInWithCustomToken } from 'firebase/auth';
-  import { onMount } from 'svelte';
-  
-  let errorMsg = $state('');
+	import { AuditLoginEngine } from './AuditLoginEngine.svelte';
+	import AuditLoginArena from './AuditLoginArena.svelte';
+	import AuditLoginHUD from './AuditLoginHUD.svelte';
 
-  onMount(async () => {
-    if (browser) {
-      try {
-        const urlParams = new URLSearchParams(window.location.search);
-        const token = urlParams.get('token');
-        if (token) {
-          await signInWithCustomToken(auth, token);
-          window.location.href = '/';
-        } else {
-          errorMsg = 'No token provided in URL';
-        }
-      } catch (err: any) {
-        errorMsg = err.message || String(err);
-      }
-    }
-  });
+	const engine = new AuditLoginEngine();
 </script>
-<h1>Audit Login in progress...</h1>
-{#if errorMsg}
-  <p style="color: red;">Error: {errorMsg}</p>
-{/if}
+
+<svelte:head>
+	<title>Audit Login | Nexus Command</title>
+</svelte:head>
+
+<div class="tw-min-h-screen tw-bg-[#020617] tw-text-[#fafafa] tw-p-8 tw-flex tw-flex-col tw-items-center tw-justify-center">
+	<div class="tw-w-full tw-max-w-md tw-bg-[#0f172a] tw-p-8 tw-rounded-xl tw-border tw-border-[#334155]">
+		<AuditLoginArena {engine} />
+		<AuditLoginHUD {engine} />
+	</div>
+</div>

--- a/src/routes/audit-login/AuditLoginArena.svelte
+++ b/src/routes/audit-login/AuditLoginArena.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+	import type { AuditLoginEngine } from './AuditLoginEngine.svelte';
+
+	let { engine }: { engine: AuditLoginEngine } = $props();
+
+	function onsubmit(e: Event) {
+		e.preventDefault();
+		void engine.handleLogin();
+	}
+</script>
+
+<h1>Audit Login</h1>
+<p>Please enter your secure audit token to proceed.</p>
+
+<form {onsubmit} class="tw-flex tw-flex-col tw-gap-4 tw-max-w-md">
+	<div>
+		<label for="audit-token" class="tw-block tw-text-sm tw-font-bold tw-mb-2">Secure Token</label>
+		<input
+			id="audit-token"
+			type="password"
+			bind:value={engine.token}
+			placeholder="Paste token here"
+			class="tw-w-full tw-p-2 tw-border tw-border-[#334155] tw-bg-transparent tw-rounded tw-text-[#fafafa] focus:tw-border-[#14b8a6] focus:tw-outline-none"
+			disabled={engine.loading}
+		/>
+	</div>
+
+	<button
+		type="submit"
+		class="tw-bg-[#14b8a6]/10 tw-text-[#14b8a6] tw-px-4 tw-py-2 tw-rounded tw-font-bold hover:tw-bg-[#14b8a6]/20 disabled:tw-opacity-50 tw-transition-colors tw-border tw-border-[#14b8a6]/20"
+		disabled={engine.loading}
+	>
+		{engine.loading ? 'Authenticating...' : 'Sign In'}
+	</button>
+</form>

--- a/src/routes/audit-login/AuditLoginEngine.svelte.ts
+++ b/src/routes/audit-login/AuditLoginEngine.svelte.ts
@@ -1,0 +1,29 @@
+import { auth } from '$lib/firebase.js';
+import { signInWithCustomToken } from 'firebase/auth';
+
+export class AuditLoginEngine {
+	token = $state('');
+	errorMsg = $state('');
+	loading = $state(false);
+
+	async handleLogin() {
+		if (!this.token.trim()) {
+			this.errorMsg = 'Please enter a valid token.';
+			return;
+		}
+
+		this.errorMsg = '';
+		this.loading = true;
+		try {
+			await signInWithCustomToken(auth, this.token.trim());
+			window.location.href = '/';
+		} catch (err: unknown) {
+			if (err instanceof Error) {
+				this.errorMsg = err.message;
+			} else {
+				this.errorMsg = String(err);
+			}
+			this.loading = false;
+		}
+	}
+}

--- a/src/routes/audit-login/AuditLoginHUD.svelte
+++ b/src/routes/audit-login/AuditLoginHUD.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+	import type { AuditLoginEngine } from './AuditLoginEngine.svelte';
+
+	let { engine }: { engine: AuditLoginEngine } = $props();
+</script>
+
+{#if engine.errorMsg}
+	<p style="color: red;" class="tw-mt-4 tw-font-bold" role="alert">Error: {engine.errorMsg}</p>
+{/if}


### PR DESCRIPTION
🎯 **What:** Fixed an authentication token exposure vulnerability in the `/audit-login` route, where custom JWT tokens were read directly from URL query parameters. The component has also been refactored into the Vanguard Trinity pattern.
⚠️ **Risk:** Tokens exposed in the URL can be inadvertently logged in browser history, proxy server logs, and HTTP referer headers, making them vulnerable to interception and replay attacks by malicious actors.
🛡️ **Solution:** Replaced the URL parameter extraction with a secure form UI (Glass layer). Support staff / automated tools can now enter the token manually into the form, which submits it directly to the Svelte 5 Engine (Brain) in-memory to trigger `signInWithCustomToken()`. This eliminates all trace of the token in the URL and conforms to the project's zero-trust and architectural mandates.

---
*PR created automatically by Jules for task [8576545820801978434](https://jules.google.com/task/8576545820801978434) started by @blueneekone*