### PR TITLE
audit(commissioner-os): lock down ODP analytics and gate cross-tenant rosters

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -102,8 +102,18 @@ service cloud.firestore {
       }
     }
 
+    function isCommissioner() {
+      return isAuthenticated() && request.auth.token.role == 'commissioner';
+    }
+
     match /rosters/{teamId} {
       allow read: if isAuthenticated();
+      allow write: if isGlobalAdmin() || (isAuthenticated() && !isCommissioner());
+    }
+
+    match /direct_messages/{messageId} {
+      allow read: if isAuthenticated();
+      allow write: if isAuthenticated() && !isCommissioner();
     }
 
     match /sports_configs/{sportId} {

--- a/src/lib/components/commissioner/CommissionerArena.svelte
+++ b/src/lib/components/commissioner/CommissionerArena.svelte
@@ -44,12 +44,19 @@
 					<tbody>
 						{#await engine.loadFederationCompliance()}
 							<tr>
-								<td colspan="3" class="tw-py-8 tw-text-center tw-text-amber-500">
-									<div class="tw-flex tw-items-center tw-justify-center tw-gap-2">
-										<Icon name={"status.loading" as IconName} size={16} class="tw-animate-spin" />
-										SCANNING REGISTRY...
-									</div>
-								</td>
+								<td class="tw-py-2.5 tw-px-2"><div class="tw-w-24 tw-h-4 tw-bg-[#1E293B] tw-animate-pulse"></div></td>
+								<td class="tw-py-2.5 tw-px-2"><div class="tw-w-16 tw-h-4 tw-bg-[#1E293B] tw-animate-pulse"></div></td>
+								<td class="tw-py-2.5 tw-px-2"><div class="tw-w-10 tw-h-4 tw-bg-[#1E293B] tw-animate-pulse tw-ml-auto"></div></td>
+							</tr>
+							<tr>
+								<td class="tw-py-2.5 tw-px-2"><div class="tw-w-24 tw-h-4 tw-bg-[#1E293B] tw-animate-pulse"></div></td>
+								<td class="tw-py-2.5 tw-px-2"><div class="tw-w-16 tw-h-4 tw-bg-[#1E293B] tw-animate-pulse"></div></td>
+								<td class="tw-py-2.5 tw-px-2"><div class="tw-w-10 tw-h-4 tw-bg-[#1E293B] tw-animate-pulse tw-ml-auto"></div></td>
+							</tr>
+							<tr>
+								<td class="tw-py-2.5 tw-px-2"><div class="tw-w-24 tw-h-4 tw-bg-[#1E293B] tw-animate-pulse"></div></td>
+								<td class="tw-py-2.5 tw-px-2"><div class="tw-w-16 tw-h-4 tw-bg-[#1E293B] tw-animate-pulse"></div></td>
+								<td class="tw-py-2.5 tw-px-2"><div class="tw-w-10 tw-h-4 tw-bg-[#1E293B] tw-animate-pulse tw-ml-auto"></div></td>
 							</tr>
 						{:then complianceData}
 							{#each complianceData as item}
@@ -104,12 +111,14 @@
 					<tbody>
 						{#await engine.loadTournamentOperations()}
 							<tr>
-								<td colspan="3" class="tw-py-8 tw-text-center tw-text-amber-500">
-									<div class="tw-flex tw-items-center tw-justify-center tw-gap-2">
-										<Icon name={"status.loading" as IconName} size={16} class="tw-animate-spin" />
-										INITIALIZING SCHEDULES...
-									</div>
-								</td>
+								<td class="tw-py-2.5 tw-px-2"><div class="tw-w-20 tw-h-4 tw-bg-[#1E293B] tw-animate-pulse"></div></td>
+								<td class="tw-py-2.5 tw-px-2 tw-flex tw-justify-center"><div class="tw-w-16 tw-h-4 tw-bg-[#1E293B] tw-animate-pulse"></div></td>
+								<td class="tw-py-2.5 tw-px-2"><div class="tw-w-8 tw-h-4 tw-bg-[#1E293B] tw-animate-pulse tw-ml-auto"></div></td>
+							</tr>
+							<tr>
+								<td class="tw-py-2.5 tw-px-2"><div class="tw-w-20 tw-h-4 tw-bg-[#1E293B] tw-animate-pulse"></div></td>
+								<td class="tw-py-2.5 tw-px-2 tw-flex tw-justify-center"><div class="tw-w-16 tw-h-4 tw-bg-[#1E293B] tw-animate-pulse"></div></td>
+								<td class="tw-py-2.5 tw-px-2"><div class="tw-w-8 tw-h-4 tw-bg-[#1E293B] tw-animate-pulse tw-ml-auto"></div></td>
 							</tr>
 						{:then operationsData}
 							{#each operationsData as item}

--- a/src/lib/components/commissioner/VanguardPrism.svelte
+++ b/src/lib/components/commissioner/VanguardPrism.svelte
@@ -3,26 +3,30 @@
 		size = 400,
 		sixAxis = null,
 		metrics = {
-			speed: 50,
+			pace: 50,
+			accel: 50,
 			agility: 50,
-			power: 50,
 			stamina: 50,
-			vision: 50,
-			technique: 50
+			power: 50,
+			comp: 50
 		},
 		playerLabel = ''
 	} = $props();
 
-	// If sixAxis array is passed, map it to metrics structure:
+	// Validate and map sixAxis array if passed
 	const activeMetrics = $derived.by(() => {
 		if (sixAxis && Array.isArray(sixAxis)) {
+			// Throw validation error if metrics are not properly ordered/sized
+			if (sixAxis.length !== 6) {
+				throw new Error('VanguardPrism validation error: sixAxis telemetry must be exactly 6 values in order [PACE, ACCEL, AGILITY, STAMINA, POWER, COMP]');
+			}
 			return {
-				speed: sixAxis[0] ?? 50,
-				agility: sixAxis[1] ?? 50,
-				power: sixAxis[2] ?? 50,
+				pace: sixAxis[0] ?? 50,
+				accel: sixAxis[1] ?? 50,
+				agility: sixAxis[2] ?? 50,
 				stamina: sixAxis[3] ?? 50,
-				vision: sixAxis[4] ?? 50,
-				technique: sixAxis[5] ?? 50
+				power: sixAxis[4] ?? 50,
+				comp: sixAxis[5] ?? 50
 			};
 		}
 		return metrics;
@@ -33,7 +37,7 @@
 
 	// Calculate polygon points for the 6-axis chart
 	const points = $derived.by(() => {
-		const axes = ['speed', 'agility', 'power', 'stamina', 'vision', 'technique'] as const;
+		const axes = ['pace', 'accel', 'agility', 'stamina', 'power', 'comp'] as const;
 
 		return axes.map((axis, i) => {
 			const angle = (Math.PI / 3) * i - Math.PI / 2;
@@ -54,12 +58,12 @@
 	});
 
 	const labels = [
-		{ text: 'SPEED', x: 600, y: 150, align: 'middle' },
-		{ text: 'AGILITY', x: 830, y: 295, align: 'start' },
-		{ text: 'POWER', x: 830, y: 505, align: 'start' },
+		{ text: 'PACE', x: 600, y: 150, align: 'middle' },
+		{ text: 'ACCEL', x: 830, y: 295, align: 'start' },
+		{ text: 'AGILITY', x: 830, y: 505, align: 'start' },
 		{ text: 'STAMINA', x: 600, y: 650, align: 'middle' },
-		{ text: 'VISION', x: 370, y: 505, align: 'end' },
-		{ text: 'TECHNIQUE', x: 370, y: 295, align: 'end' }
+		{ text: 'POWER', x: 370, y: 505, align: 'end' },
+		{ text: 'COMP', x: 370, y: 295, align: 'end' }
 	];
 </script>
 

--- a/src/routes/(app)/commissioner/FederationEngine.svelte.ts
+++ b/src/routes/(app)/commissioner/FederationEngine.svelte.ts
@@ -63,6 +63,9 @@ export class FederationEngine {
 			return [];
 		}
 
+		const db = getActiveDb();
+		if (!db || !authStore.isAuthenticated) return [];
+
 		this.isLoading = true;
 		this.error = null;
 

--- a/src/routes/(app)/commissioner/TournamentEngine.svelte.ts
+++ b/src/routes/(app)/commissioner/TournamentEngine.svelte.ts
@@ -216,12 +216,14 @@ export class TournamentEngine {
 		if (!isFirestoreReady()) {
 			return;
 		}
+		const db = getActiveDb();
+		if (!db || !authStore.isAuthenticated) {
+			return;
+		}
 		this.isLoading = true;
 		this.error = null;
 		this.eventId = eventId;
 		try {
-			const db = getActiveDb();
-			if (!db) throw new Error('Database not available');
 			const docRef = doc(db, 'tournament_events', eventId);
 			const docSnap = await getDoc(docRef);
 			if (docSnap.exists()) {
@@ -237,6 +239,14 @@ export class TournamentEngine {
 	}
 
 	async updateLiveScore(matchId: string, scorePayload: ScorePayload) {
+		if (!isFirestoreReady()) {
+			throw new Error('Database not available or user not authenticated');
+		}
+		const db = getActiveDb();
+		if (!db || !authStore.isAuthenticated) {
+			throw new Error('Database not available or user not authenticated');
+		}
+
 		if (!this.bracket || !this.eventId) {
 			throw new Error('No bracket or event loaded');
 		}
@@ -258,9 +268,6 @@ export class TournamentEngine {
 				propagateTeams(this.bracket.matches, matchId, winId, loseId);
 			}
 		}
-
-		const db = getActiveDb();
-		if (!db) throw new Error('Database not available');
 
 		const batch = writeBatch(db);
 		const eventRef = doc(db, 'tournament_events', this.eventId);

--- a/src/routes/(app)/commissioner/dashboard/CommissionerDashboardEngine.svelte.ts
+++ b/src/routes/(app)/commissioner/dashboard/CommissionerDashboardEngine.svelte.ts
@@ -14,24 +14,24 @@ export type ClubCompliance = {
 };
 
 export type OdpMetrics = {
-	speed: number;
+	pace: number;
+	accel: number;
 	agility: number;
-	power: number;
 	stamina: number;
-	vision: number;
-	technique: number;
+	power: number;
+	comp: number;
 };
 
 export class CommissionerDashboardEngine {
 	// Svelte 5 Rune State
 	clubs = $state<ClubCompliance[]>([]);
 	odpMetrics = $state<OdpMetrics>({
-		speed: 50,
+		pace: 50,
+		accel: 50,
 		agility: 50,
-		power: 50,
 		stamina: 50,
-		vision: 50,
-		technique: 50
+		power: 50,
+		comp: 50
 	});
 	isLoading = $state(true);
 	error = $state<string | null>(null);
@@ -152,12 +152,12 @@ export class CommissionerDashboardEngine {
 				}
 			];
 			this.odpMetrics = {
-				speed: 75,
-				agility: 82,
-				power: 65,
+				pace: 75,
+				accel: 82,
+				agility: 65,
 				stamina: 90,
-				vision: 70,
-				technique: 85
+				power: 70,
+				comp: 85
 			};
 			this.isLoading = false;
 			this.error = null;
@@ -211,12 +211,12 @@ export class CommissionerDashboardEngine {
 			this.clubs = loadedClubs;
 
 			this.odpMetrics = {
-				speed: 75,
-				agility: 82,
-				power: 65,
+				pace: 75,
+				accel: 82,
+				agility: 65,
 				stamina: 90,
-				vision: 70,
-				technique: 85
+				power: 70,
+				comp: 85
 			};
 
 		} catch (err: unknown) {


### PR DESCRIPTION
Execute the complete, structured remediation workflow defined in .agents\workflows\jules-builds\tdd-commissioner-os.md.

Included the following fixes:
- Added Defensive Hydration guards (`!db || !authStore.isAuthenticated`) to `FederationEngine.svelte.ts` and `TournamentEngine.svelte.ts`.
- Locked down Commissioner write abilities on team rosters and direct messages by updating `firestore.rules`.
- Fixed the visual regression layout in `CommissionerArena` to adopt a 90-degree skeleton bento-grid layout for the tables, matching Svelte 5 requirements.
- Implemented and mapped strict 6-axis analytics validation logic within `VanguardPrism.svelte` to throw an error if elements deviate from `[PACE, ACCEL, AGILITY, STAMINA, POWER, COMP]`.
- Verified and fixed backend Svelte components resulting in 100% green tests in `components/commissioner/` and `src/routes/(app)/commissioner`.

---
*PR created automatically by Jules for task [17244310387832762310](https://jules.google.com/task/17244310387832762310) started by @blueneekone*