### PR TITLE
fix(coach-os): audit and stabilize Coach OS backend and visual controls

### DIFF
--- a/functions-commerce/src/domains/webhooksOps.js
+++ b/functions-commerce/src/domains/webhooksOps.js
@@ -1,4 +1,3 @@
-const Stripe = require("stripe");
 'use strict';
 
 const crypto = require('crypto');

--- a/functions-commerce/subscription.js
+++ b/functions-commerce/subscription.js
@@ -1,4 +1,3 @@
-const Stripe = require("stripe");
 /* eslint-disable quotes */
 /**
  * subscription.js — Marketing / Stripe Checkout Stub

--- a/functions-core/index.js
+++ b/functions-core/index.js
@@ -59,3 +59,6 @@ exports.generatePdfReportCard = reportOps.generatePdfReportCard;
 const b2bEnrollmentOps = require('./src/domains/b2bEnrollmentOps.js');
 exports.enrollIndependentDirector = b2bEnrollmentOps.enrollIndependentDirector;
 exports.enrollGovernedDirector = b2bEnrollmentOps.enrollGovernedDirector;
+
+const staffPermissionsOps = require('./src/domains/staffPermissionsOps.js');
+exports.callableUpdateStaffRole = staffPermissionsOps.callableUpdateStaffRole;

--- a/functions/src/domains/scheduleOps.js
+++ b/functions/src/domains/scheduleOps.js
@@ -44,7 +44,7 @@ exports.setEventRsvp = onCall({region: REGION}, async (request) => {
     );
   }
 
-  const eventRef = db().collection('team_workouts').doc(eventId);
+  const eventRef = db().collection('schedules').doc(eventId);
   const eventSnap = await eventRef.get();
   if (!eventSnap.exists) {
     throw new HttpsError('not-found', 'Scheduled event not found.');

--- a/functions/src/domains/staffPermissionsOps.js
+++ b/functions/src/domains/staffPermissionsOps.js
@@ -1,0 +1,75 @@
+'use strict';
+
+const { onCall, HttpsError } = require('firebase-functions/v2/https');
+const admin = require('firebase-admin');
+const logger = require('firebase-functions/logger');
+
+const REGION = 'us-east1';
+const db = () => admin.firestore();
+
+const ALLOWED_STAFF_ROLES = new Set([
+  'assistant_coach',
+  'team_manager',
+  'schedule_manager',
+  'event_manager',
+  'head_coach',
+]);
+
+/**
+ * Assigns or updates a team staff role strictly scoped under:
+ * /clubs/{clubId}/teams/{teamId}/staff/{userId}
+ * Client-side direct mutations of staff roles are blocked.
+ */
+exports.callableUpdateStaffRole = onCall({ region: REGION }, async (request) => {
+  if (!request.auth) {
+    throw new HttpsError('unauthenticated', 'Authentication required.');
+  }
+
+  const callerRole = request.auth.token.role || '';
+  const tokenClub = typeof request.auth.token.clubId === 'string' ? request.auth.token.clubId.trim() : '';
+  const isSuper = ['director', 'super_admin', 'global_admin'].includes(callerRole);
+
+  const data = request.data || {};
+  const clubId = typeof data.clubId === 'string' ? data.clubId.trim() : '';
+  const teamId = typeof data.teamId === 'string' ? data.teamId.trim() : '';
+  const targetUserId = typeof data.targetUserId === 'string' ? data.targetUserId.trim() : '';
+  const newRole = typeof data.role === 'string' ? data.role.trim().toLowerCase() : '';
+
+  if (!clubId || !teamId || !targetUserId || !newRole) {
+    throw new HttpsError('invalid-argument', 'clubId, teamId, targetUserId, and role are required.');
+  }
+
+  if (!ALLOWED_STAFF_ROLES.has(newRole)) {
+    throw new HttpsError('invalid-argument', 'Invalid staff role specified.');
+  }
+
+  if (!isSuper && (!tokenClub || tokenClub !== clubId)) {
+    throw new HttpsError('permission-denied', 'You can only update staff permissions for your own club.');
+  }
+
+  const staffRef = db()
+    .collection('clubs')
+    .doc(clubId)
+    .collection('teams')
+    .doc(teamId)
+    .collection('staff')
+    .doc(targetUserId);
+
+  const now = admin.firestore.FieldValue.serverTimestamp();
+
+  await staffRef.set(
+    {
+      clubId,
+      teamId,
+      userId: targetUserId,
+      role: newRole,
+      updatedAt: now,
+      updatedBy: request.auth.uid,
+    },
+    { merge: true }
+  );
+
+  logger.info(`[callableUpdateStaffRole] Updated staff ${targetUserId} role to ${newRole} under team ${teamId} in club ${clubId}`);
+
+  return { ok: true, clubId, teamId, targetUserId, role: newRole };
+});

--- a/functions/src/domains/tryoutsOps.js
+++ b/functions/src/domains/tryoutsOps.js
@@ -1020,16 +1020,26 @@ exports.promoteTryoutToRoster = onCall({region: REGION}, async (request) => {
   const rosterRef = db().collection('rosters').doc(teamId);
   const now = admin.firestore.FieldValue.serverTimestamp();
 
-  await db().runTransaction(async (tx) => {
-    const rosterSnap = await tx.get(rosterRef);
-    const players = rosterSnap.exists && Array.isArray(rosterSnap.data().players)
-      ? rosterSnap.data().players.filter((x) => typeof x === 'string') : [];
-    const norm = playerName.toLowerCase();
-    if (!players.some((n) => String(n).trim().toLowerCase() === norm)) {
-      tx.set(rosterRef, { players: [...players, playerName], updatedAt: now }, {merge: true});
-    }
-    tx.set(regRef, { pipelineStatus: PIPELINE.ROSTER_PENDING, rosterTeamId: teamId, rosterPromotedAt: now, updatedAt: now }, {merge: true});
-  });
+  // Execute roster promotion writeBatch (capped at maximum 500 operations)
+  const rosterSnap = await rosterRef.get();
+  const players = rosterSnap.exists && Array.isArray(rosterSnap.data().players)
+    ? rosterSnap.data().players.filter((x) => typeof x === 'string') : [];
+  const norm = playerName.toLowerCase();
+
+  const batch = db().batch();
+  let ops = 0;
+  if (!players.some((n) => String(n).trim().toLowerCase() === norm)) {
+    batch.set(rosterRef, { players: [...players, playerName], updatedAt: now }, {merge: true});
+    ops++;
+  }
+  batch.set(regRef, { pipelineStatus: PIPELINE.ROSTER_PENDING, rosterTeamId: teamId, rosterPromotedAt: now, updatedAt: now }, {merge: true});
+  ops++;
+
+  if (ops <= 500) {
+    await batch.commit();
+  } else {
+    throw new HttpsError('resource-exhausted', 'Batch limit exceeded 500 operations.');
+  }
 
   const guardianEmail = normEmail(reg.guardianEmail);
   let operativeLink = {linked: false};

--- a/scripts/bundle-functions.cjs
+++ b/scripts/bundle-functions.cjs
@@ -36,6 +36,7 @@ const CODEBASES = {
       'src/domains/federationSyncOps.js',
       'src/domains/reportOps.js',
       'src/domains/b2bEnrollmentOps.js',
+      'src/domains/staffPermissionsOps.js',
       'lib/grit.js',
     ],
   },

--- a/src/routes/(app)/coach/forge/ForgeEngine.svelte.ts
+++ b/src/routes/(app)/coach/forge/ForgeEngine.svelte.ts
@@ -37,7 +37,7 @@ export class ForgeEngine {
 		if (!browser) return;
 		
 		$effect(() => {
-			if (!isFirestoreReady()) return;
+			if (!db || !authStore.isAuthenticated) return;
 			
 			const teamId = authStore.userProfile?.teamId;
 			const clubId = authStore.userProfile?.clubId;

--- a/src/routes/(app)/coach/tactical/CoachTacticalEngine.svelte.ts
+++ b/src/routes/(app)/coach/tactical/CoachTacticalEngine.svelte.ts
@@ -119,7 +119,7 @@ export class CoachTacticalEngine {
 	}
 
 	async _loadBoardState(tid: string, uid: string) {
-		if (!isFirestoreReady()) return;
+		if (!db || !authStore.isAuthenticated) return;
 		this.boardLoadComplete = false;
 		try {
 			const snap = await getDoc(doc(db, 'teams', tid, 'tactics', `wr_${uid}`));
@@ -157,7 +157,7 @@ export class CoachTacticalEngine {
 	}
 
 	async _loadRosters(tid: string) {
-		if (!isFirestoreReady()) return;
+		if (!db || !authStore.isAuthenticated) return;
 		try {
 			const snap = await getDoc(doc(db, 'rosters', tid));
 			const rostersNames = (

--- a/src/routes/(app)/coach/war-room/IntentEngine.svelte.ts
+++ b/src/routes/(app)/coach/war-room/IntentEngine.svelte.ts
@@ -50,6 +50,7 @@ export class IntentEngine {
 			where('teamId', '==', teamId)
 		);
 
+		if (!db || !authStore.isAuthenticated) return () => {};
 		const unsub = onSnapshot(
 			q,
 			(snap) => {


### PR DESCRIPTION
Executes the remediation workflow for Coach OS (Tactical SIEM), updating tryout roster promotion batch limits, standardizing scheduling collection queries, implementing team-scoped staff permission callables, enforcing defensive hydration guards across Coach OS engines, and bundling function codebases.

---
*PR created automatically by Jules for task [2271265751920605154](https://jules.google.com/task/2271265751920605154) started by @blueneekone*