### PR TITLE
Fix Coach OS Dashboard users populating error

### DIFF
--- a/src/lib/coach/__tests__/rosterDisplayDedupe.test.ts
+++ b/src/lib/coach/__tests__/rosterDisplayDedupe.test.ts
@@ -80,4 +80,39 @@ describe('rosterDisplayDedupe — LAUNCH-HOTFIX-P5', () => {
 		});
 		expect(names).toEqual(['Jordan Test']);
 	});
+
+	it('buildCoachRosterDisplayNames includes userDocs with athlete role or missing role', () => {
+		const names = buildCoachRosterDisplayNames({
+			userDocs: [
+				{
+					id: 'athlete-uid',
+					data: {
+						role: 'athlete',
+						uid: 'athlete-uid',
+						playerName: 'Avery Athlete',
+					},
+				},
+				{
+					id: 'no-role-uid',
+					data: {
+						uid: 'no-role-uid',
+						playerName: 'Taylor Player',
+					},
+				},
+				{
+					id: 'coach-uid',
+					data: {
+						role: 'coach',
+						uid: 'coach-uid',
+						playerName: 'Coach Carter',
+					},
+				},
+			],
+			rosterNames: [],
+			statsKeys: [],
+			statsByKey: {},
+			linkedNameToEmail: {},
+		});
+		expect(names).toEqual(['Avery Athlete', 'Taylor Player']);
+	});
 });

--- a/src/lib/coach/rosterDisplayDedupe.ts
+++ b/src/lib/coach/rosterDisplayDedupe.ts
@@ -86,8 +86,20 @@ export function buildCoachRosterDisplayNames(input: {
 	statsByKey: Record<string, { playerName?: unknown }>;
 	linkedNameToEmail: Record<string, string>;
 }): string[] {
+	const staffRoles = new Set([
+		'coach',
+		'director',
+		'parent',
+		'admin',
+		'super_admin',
+		'global_admin',
+		'registrar',
+		'commissioner',
+		'recruiter',
+	]);
+
 	const userRows = input.userDocs
-		.filter((d) => d.data.role === 'player')
+		.filter((d) => !d.data.role || !staffRoles.has(String(d.data.role)))
 		.map((d) => {
 			const x = d.data;
 			const authUid = isValidAuthUid(x.uid) ? String(x.uid).trim() : '';


### PR DESCRIPTION
Fixed the no users populating issue on the Coach OS dashboard by expanding buildCoachRosterDisplayNames in rosterDisplayDedupe.ts to filter out staff/admin/parent roles explicitly while including athlete and unassigned user roles. Added unit tests verifying athlete and unassigned user inclusion.

---
*PR created automatically by Jules for task [10452514663775507918](https://jules.google.com/task/10452514663775507918) started by @blueneekone*