### PR TITLE
🧪 [testing improvement] Add edge case tests for formatVariantLabel

### DIFF
--- a/src/lib/gamification/__tests__/seasonOneData.test.ts
+++ b/src/lib/gamification/__tests__/seasonOneData.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { formatVariantLabel } from '../seasonOneData.js';
+
+describe('formatVariantLabel', () => {
+	it('formats known sticker variants correctly', () => {
+		expect(formatVariantLabel('holo')).toBe('Holo');
+		expect(formatVariantLabel('radiant')).toBe('Radiant');
+		expect(formatVariantLabel('alt-art')).toBe('Alt Art');
+		expect(formatVariantLabel('base')).toBe('Base');
+	});
+
+	it('falls back to "Base" for unexpected or edge case inputs', () => {
+		const unexpectedInputs = [
+			'unknown',
+			'INVALID',
+			'',
+			undefined,
+			null,
+			123,
+			false,
+			true,
+			{},
+			[],
+		];
+
+		for (const input of unexpectedInputs) {
+			// @ts-expect-error - testing unexpected runtime inputs
+			expect(formatVariantLabel(input)).toBe('Base');
+		}
+	});
+});


### PR DESCRIPTION
Adds unit test coverage for formatVariantLabel in src/lib/gamification/seasonOneData.js, verifying known sticker variants and default fallback behavior on unexpected inputs.

---
*PR created automatically by Jules for task [3080632877397042105](https://jules.google.com/task/3080632877397042105) started by @blueneekone*