### PR TITLE
🧪 add unit tests for computePlatformFee billing logic

### DIFF
--- a/src/lib/services/__tests__/helpers/pricingFixtures.ts
+++ b/src/lib/services/__tests__/helpers/pricingFixtures.ts
@@ -1,0 +1,55 @@
+import type { PricingPolicyDoc } from '$lib/types/pricing';
+
+export const mockPercentagePolicy: PricingPolicyDoc = {
+	id: 'default-v1',
+	version: 1,
+	rateCard: {
+		season_registration: { rateBp: 250, minimumFeeCents: 50 },
+		merch_sale: { rateBp: 300 },
+	},
+	volumeBreakpoints: [],
+	maxFeeCentsPerTxn: 5000,
+};
+
+export const mockFlatPolicy: PricingPolicyDoc = {
+	id: 'flat-v1',
+	version: 1,
+	rateCard: {
+		recruiter_lead_export: { flatFeeCents: 100 },
+	},
+	volumeBreakpoints: [],
+	maxFeeCentsPerTxn: 50,
+};
+
+export const mockContradictoryPolicy: PricingPolicyDoc = {
+	id: 'invalid-v1',
+	version: 1,
+	rateCard: {
+		season_registration: { rateBp: 200, flatFeeCents: 50 } as any,
+	},
+	volumeBreakpoints: [],
+	maxFeeCentsPerTxn: null,
+};
+
+export const mockRebatePolicy: PricingPolicyDoc = {
+	id: 'rebate-v1',
+	version: 1,
+	rateCard: {
+		hotel_rebate: { rateBp: -7000 },
+	},
+	volumeBreakpoints: [],
+	maxFeeCentsPerTxn: null,
+};
+
+export const mockVolumePolicy: PricingPolicyDoc = {
+	id: 'volume-v1',
+	version: 1,
+	rateCard: {
+		season_registration: { rateBp: 1000 },
+	},
+	volumeBreakpoints: [
+		{ ytdGrossCentsThreshold: 100000, rateModifier: 0.8 },
+		{ ytdGrossCentsThreshold: 500000, rateModifier: 0.5 },
+	],
+	maxFeeCentsPerTxn: null,
+};

--- a/src/lib/services/__tests__/pricingEngine.test.ts
+++ b/src/lib/services/__tests__/pricingEngine.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { computePlatformFee } from '../pricingEngine.svelte.js';
+import {
+	mockPercentagePolicy,
+	mockFlatPolicy,
+	mockContradictoryPolicy,
+} from './helpers/pricingFixtures.js';
+
+describe('computePlatformFee - Validation & Core Rules', () => {
+	it('throws RangeError for invalid grossCents inputs', () => {
+		expect(() =>
+			computePlatformFee({ policy: mockPercentagePolicy, transactionType: 'season_registration', grossCents: -10 }),
+		).toThrow(RangeError);
+		expect(() =>
+			computePlatformFee({ policy: mockPercentagePolicy, transactionType: 'season_registration', grossCents: 10.5 }),
+		).toThrow(RangeError);
+		expect(() =>
+			computePlatformFee({ policy: mockPercentagePolicy, transactionType: 'season_registration', grossCents: NaN }),
+		).toThrow(RangeError);
+	});
+
+	it('throws RangeError when rateCard entry has both rateBp and flatFeeCents', () => {
+		expect(() =>
+			computePlatformFee({ policy: mockContradictoryPolicy, transactionType: 'season_registration', grossCents: 1000 }),
+		).toThrow(RangeError);
+	});
+
+	it('returns zero fee when transaction type is not configured in rateCard', () => {
+		const res = computePlatformFee({ policy: mockPercentagePolicy, transactionType: 'hotel_rebate', grossCents: 5000 });
+		expect(res).toEqual({ platformFeeCents: 0, netCents: 5000, rateBp: 0, policyVersion: 1, flatFee: false });
+	});
+
+	it('calculates flat fee and applies max cap', () => {
+		const res = computePlatformFee({ policy: mockFlatPolicy, transactionType: 'recruiter_lead_export', grossCents: 1000 });
+		expect(res).toEqual({ platformFeeCents: 50, netCents: 950, rateBp: 0, policyVersion: 1, flatFee: true });
+	});
+
+	it('calculates percentage rate, applies minimum fee floor, and maximum fee cap', () => {
+		// 250 bp on 100 gross = 2.5 cents -> rounded to 3 cents, but min fee is 50
+		const resMin = computePlatformFee({ policy: mockPercentagePolicy, transactionType: 'season_registration', grossCents: 100 });
+		expect(resMin.platformFeeCents).toBe(50);
+
+		// 250 bp on 10000 gross = 250 cents
+		const resStandard = computePlatformFee({ policy: mockPercentagePolicy, transactionType: 'season_registration', grossCents: 10000 });
+		expect(resStandard).toEqual({ platformFeeCents: 250, netCents: 9750, rateBp: 250, policyVersion: 1, flatFee: false });
+
+		// 250 bp on 300000 gross = 7500 cents -> capped at maxFeeCentsPerTxn = 5000
+		const resCap = computePlatformFee({ policy: mockPercentagePolicy, transactionType: 'season_registration', grossCents: 300000 });
+		expect(resCap.platformFeeCents).toBe(5000);
+	});
+});

--- a/src/lib/services/__tests__/pricingEngineVolume.test.ts
+++ b/src/lib/services/__tests__/pricingEngineVolume.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { computePlatformFee } from '../pricingEngine.svelte.js';
+import { mockVolumePolicy, mockRebatePolicy } from './helpers/pricingFixtures.js';
+
+describe('computePlatformFee - Volume Breakpoints & Negative Rates', () => {
+	it('applies base rate when ytdGrossCents is absent or below threshold', () => {
+		const res0 = computePlatformFee({
+			policy: mockVolumePolicy,
+			transactionType: 'season_registration',
+			grossCents: 10000,
+		});
+		expect(res0.rateBp).toBe(1000);
+		expect(res0.platformFeeCents).toBe(1000);
+
+		const resBelow = computePlatformFee({
+			policy: mockVolumePolicy,
+			transactionType: 'season_registration',
+			grossCents: 10000,
+			ytdGrossCents: 50000,
+		});
+		expect(resBelow.rateBp).toBe(1000);
+	});
+
+	it('applies modifier when ytdGrossCents reaches or exceeds volume thresholds', () => {
+		// Tier 1: threshold 100000, modifier 0.8 -> 1000 * 0.8 = 800 bp
+		const resTier1 = computePlatformFee({
+			policy: mockVolumePolicy,
+			transactionType: 'season_registration',
+			grossCents: 10000,
+			ytdGrossCents: 100000,
+		});
+		expect(resTier1.rateBp).toBe(800);
+		expect(resTier1.platformFeeCents).toBe(800);
+
+		// Tier 2: threshold 500000, modifier 0.5 -> 1000 * 0.5 = 500 bp
+		const resTier2 = computePlatformFee({
+			policy: mockVolumePolicy,
+			transactionType: 'season_registration',
+			grossCents: 10000,
+			ytdGrossCents: 600000,
+		});
+		expect(resTier2.rateBp).toBe(500);
+		expect(resTier2.platformFeeCents).toBe(500);
+	});
+
+	it('handles negative rateBp for rebate flows', () => {
+		const res = computePlatformFee({
+			policy: mockRebatePolicy,
+			transactionType: 'hotel_rebate',
+			grossCents: 10000,
+		});
+		expect(res.rateBp).toBe(-7000);
+		expect(res.platformFeeCents).toBe(-7000);
+		expect(res.netCents).toBe(17000);
+	});
+});


### PR DESCRIPTION
Adds unit tests for `computePlatformFee` in `src/lib/services/pricingEngine.svelte.ts`.

### 🎯 What
Addressed untested billing logic in `computePlatformFee` pure function.

### 📊 Coverage
- Input validation (`grossCents` negative, floating point, NaN).
- Rate card entry contradiction check (rateBp vs flatFeeCents).
- Unconfigured transaction fallback.
- Flat fee calculations and max fee caps.
- Percentage calculations with minimum fee floors and maximum fee caps.
- Volume breakpoint multipliers for YTD gross volume.
- Negative rate basis points for rebate calculations.

### ✨ Result
Improved reliability and coverage of client-side pricing calculation logic, keeping test files modular and under 80 lines.

---
*PR created automatically by Jules for task [967398642977616751](https://jules.google.com/task/967398642977616751) started by @blueneekone*