### PR TITLE
🧹 [code health] Remove debug console.log from postAuthRouting

### DIFF
--- a/src/lib/auth/postAuthRouting.ts
+++ b/src/lib/auth/postAuthRouting.ts
@@ -39,7 +39,6 @@ export async function navigateAfterLogin(
 		return;
 	}
 
-	console.log('DEBUG [postAuthRouting]: authStore state', { isProfileComplete: authStore.isProfileComplete, role: authStore.role, profile: authStore.userProfile });
 	if (!authStore.isProfileComplete) {
 		await untrack(() => goto('/onboarding', { replaceState }));
 		return;


### PR DESCRIPTION
### 🎯 What
Removed a debug `console.log` statement left in `src/lib/auth/postAuthRouting.ts` (`navigateAfterLogin`).

### 💡 Why
Cleaning up leftover console logging improves codebase health, maintainability, and prevents stdout noise during authentication flows and test executions.

### ✅ Verification
- Executed `npx vitest run src/lib/auth/__tests__/postAuthRouting.test.ts` (9 tests passed cleanly with no console log output).
- Verified with `npx eslint src/lib/auth/postAuthRouting.ts` (0 lint errors).
- Executed `pnpm run check` (0 type errors).

### ✨ Result
Code health issue resolved cleanly without impacting navigation logic or application behavior.

---
*PR created automatically by Jules for task [8761249923141880652](https://jules.google.com/task/8761249923141880652) started by @blueneekone*