### PR TITLE
Update marketing landing page to asymmetric 12-column Bento Grid weighting

### DIFF
--- a/src/routes/(marketing)/+page.svelte
+++ b/src/routes/(marketing)/+page.svelte
@@ -19,7 +19,7 @@
 			body: 'Gamified Skill Trees, XP progression, Vanguard Prism radars, and video trial uploads driving intrinsic motivation and unyielding athlete engagement.',
 			href: '/player',
 			hoverColor: '#fbbf24',
-			cols: 'md:tw-col-span-4',
+			cols: 'md:tw-col-span-8',
 			bento: 'player'
 		},
 		{
@@ -43,7 +43,7 @@
 			body: 'COPPA 2.0 WebAuthn biometric gating, SafeSport Shadow CC routing, and the Car Ride Home emotional safety protocol.',
 			href: '/parent',
 			hoverColor: '#14b8a6',
-			cols: 'md:tw-col-span-4',
+			cols: 'md:tw-col-span-12',
 			bento: 'parent'
 		}
 	];
@@ -139,7 +139,7 @@
 			<p class="tw-text-[#D4D4D8] tw-mt-4 tw-max-w-2xl" style="font-family: 'Switzer', sans-serif;">Complete operational parity across your club's most critical personas.</p>
 		</div>
 
-		<!-- Symmetric: 4 / 4 / 4 column weighting -->
+		<!-- Asymmetric: 8 / 4 / 12 column weighting -->
 		<div class="tw-grid tw-grid-cols-1 md:tw-grid-cols-12 tw-gap-4 md:tw-gap-6">
 			{#each features as feat}
 				<div data-bento={feat.bento} class="tw-col-span-1 {feat.cols} tw-transition-all tw-duration-300 tw-h-full bento-wrapper">

--- a/src/routes/(marketing)/__tests__/marketingLanding.test.ts
+++ b/src/routes/(marketing)/__tests__/marketingLanding.test.ts
@@ -2,13 +2,11 @@ import { describe, it, expect } from 'vitest';
 import PageSource from '../+page.svelte?raw';
 
 describe('CDO Protocol: Marketing Landing Page Audit', () => {
-	it('MUST enforce the strict 12-column symmetric Bento Grid (4/4/4)', () => {
-		// The `features` array should define the equal col-spans.
+	it('MUST enforce the strict 12-column asymmetric Bento Grid (8/4/12)', () => {
+		// The `features` array should define asymmetrical col-spans.
+		expect(PageSource).toContain("cols: 'md:tw-col-span-8'");
 		expect(PageSource).toContain("cols: 'md:tw-col-span-4'");
-		
-		// It should contain three symmetrical 4-columns
-		const count4Col = (PageSource.match(/md:tw-col-span-4/g) || []).length;
-		expect(count4Col).toBe(3);
+		expect(PageSource).toContain("cols: 'md:tw-col-span-12'");
 	});
 
 	it('MUST absolutely eradicate unauthorized dark hex codes (#0B0F19, #1e293b)', () => {


### PR DESCRIPTION
Replaces symmetrical 4/4/4 column spans in the ecosystem section of src/routes/(marketing)/+page.svelte with an asymmetrical 12-column weighting (Player OS: 8 cols, Coach OS: 4 cols, Parent OS: 12 cols). Also updates the corresponding unit test suite to assert the asymmetrical grid contract.

---
*PR created automatically by Jules for task [15111820474127327166](https://jules.google.com/task/15111820474127327166) started by @blueneekone*