### PR TITLE
Add unit test for sub-10 word brutalist headline

### DIFF
--- a/src/routes/(marketing)/__tests__/marketingLanding.test.ts
+++ b/src/routes/(marketing)/__tests__/marketingLanding.test.ts
@@ -25,4 +25,12 @@ describe('CDO Protocol: Marketing Landing Page Audit', () => {
 		expect(PageSource).not.toMatch(/\/60/);
 		expect(PageSource).not.toMatch(/-\[0\.03\]/);
 	});
+
+	it('MUST enforce a brutalist headline under 10 words', () => {
+		const h1Match = PageSource.match(/<h1[^>]*>([\s\S]*?)<\/h1>/i);
+		expect(h1Match).not.toBeNull();
+		const h1Text = h1Match![1].replace(/<[^>]*>/g, '').trim();
+		const wordCount = h1Text.split(/\s+/).filter(Boolean).length;
+		expect(wordCount).toBeLessThan(10);
+	});
 });


### PR DESCRIPTION
Verified that the hero headline in src/routes/(marketing)/+page.svelte is under 10 words ("Focus on development, not just management.") and added a Vitest test in marketingLanding.test.ts to enforce this requirement.

---
*PR created automatically by Jules for task [18309889939280573922](https://jules.google.com/task/18309889939280573922) started by @blueneekone*