### PR TITLE
Fix functions-commerce CommonJS export syntax for clean deployment and build

### DIFF
--- a/functions-commerce/index.js
+++ b/functions-commerce/index.js
@@ -56,4 +56,3 @@ exports.dunningCommsDispatch = dunningOps.dunningCommsDispatch;
 
 const tutoringOps = require('./src/domains/tutoringOps');
 exports.bookTutoringSession = tutoringOps.bookTutoringSession;
-export { bookTutoringSession } from './src/domains/stripeConnect.js';


### PR DESCRIPTION
Fixed invalid CommonJS module syntax in functions-commerce/index.js. Cleaned up function deployment and verified that pnpm run check and pnpm run build pass with 0 errors, alongside all unit and deployment tests.

---
*PR created automatically by Jules for task [9087874370261251960](https://jules.google.com/task/9087874370261251960) started by @blueneekone*