### PR TITLE
Harden WebAuthn passkey registration options and sync compliance package

### DIFF
--- a/functions-compliance/webauthn.js
+++ b/functions-compliance/webauthn.js
@@ -125,8 +125,8 @@ exports.webauthnRegisterStart = onCall(
       rpName: RP_NAME,
       rpID: rpID,
       userID: new TextEncoder().encode(uid),
-      userName: request.auth.token.email || uid,
-      userDisplayName: request.auth.token.name || request.auth.token.email || uid,
+      userName: request.auth.token.email || uid || 'user',
+      userDisplayName: request.auth.token.name || request.auth.token.email || uid || 'user',
       attestationType: 'none',
       excludeCredentials: existingCreds.map((c) => ({
         id: c.id,

--- a/functions/webauthn.js
+++ b/functions/webauthn.js
@@ -125,8 +125,8 @@ exports.webauthnRegisterStart = onCall(
       rpName: RP_NAME,
       rpID: rpID,
       userID: new TextEncoder().encode(uid),
-      userName: request.auth.token.email || uid,
-      userDisplayName: request.auth.token.name || request.auth.token.email || uid,
+      userName: request.auth.token.email || uid || 'user',
+      userDisplayName: request.auth.token.name || request.auth.token.email || uid || 'user',
       attestationType: 'none',
       excludeCredentials: existingCreds.map((c) => ({
         id: c.id,


### PR DESCRIPTION
Harden WebAuthn passkey registration options in functions/webauthn.js and functions-compliance/webauthn.js by providing robust fallbacks for userName and userDisplayName when token claims are absent. Ensure dependencies in functions-compliance/ are installed, split function packages bundled, and pnpm run check && pnpm run build pass with 0 errors.

---
*PR created automatically by Jules for task [15806279121070707971](https://jules.google.com/task/15806279121070707971) started by @blueneekone*