### PR TITLE
fix(auth): enforce b815 hydration and jwt token refresh for director os

### DIFF
--- a/src/lib/auth/postAuthRouting.ts
+++ b/src/lib/auth/postAuthRouting.ts
@@ -29,6 +29,7 @@ export async function navigateAfterLogin(
 
 	try {
 		await auth.currentUser?.getIdToken(true);
+		await authStore.refreshClaims();
 	} catch {
 		/* non-fatal */
 	}

--- a/src/lib/components/director/DirectorBillingAuditPanel.svelte
+++ b/src/lib/components/director/DirectorBillingAuditPanel.svelte
@@ -72,7 +72,7 @@
 
 	// ── Load ───────────────────────────────────────────────────────────────────
 	$effect(() => {
-		if (!db || !authStore.isAuthenticated) return;
+		if (!db || !authStore.isAuthenticated || !authStore.clubId) return;
 		const id = clubId.trim();
 		if (!id) {
 			lastLoadedClubId = '';
@@ -148,7 +148,7 @@
 	});
 
 	async function refreshNow() {
-    if (!db || !authStore.isAuthenticated) return;
+		if (!db || !authStore.isAuthenticated || !authStore.clubId) return;
 		const id = clubId.trim();
 		if (!id) return;
 		lastLoadedClubId = '';

--- a/src/lib/components/director/MarketingTab.svelte
+++ b/src/lib/components/director/MarketingTab.svelte
@@ -73,7 +73,6 @@
 	];
 
 	function slugifyInput(raw) {
-    if (!db || !authStore.isAuthenticated) return;
 		return String(raw || '')
 			.trim()
 			.toLowerCase()
@@ -90,7 +89,7 @@
 	}
 
 	$effect(() => {
-		if (!db || !authStore.isAuthenticated) return;
+		if (!db || !authStore.isAuthenticated || !authStore.clubId) return;
 		const cid = effectiveClubId;
 		if (!cid) {
 			publicSlug = '';

--- a/src/lib/components/director/OrgDashboard.svelte
+++ b/src/lib/components/director/OrgDashboard.svelte
@@ -67,6 +67,7 @@
 	}
 
 	$effect(() => {
+		if (!db || !authStore.isAuthenticated || !authStore.clubId) return;
 		if (!browser || !tenantId) {
 			detach();
 			org = null;

--- a/src/lib/components/director/PlaybookTab.svelte
+++ b/src/lib/components/director/PlaybookTab.svelte
@@ -61,7 +61,7 @@
 	const formationOptions = ['4-3-3', '4-4-2', '4-2-3-1', '3-5-2', '3-4-3', '5-3-2'];
 
 	async function loadEntries() {
-    if (!db || !authStore.isAuthenticated) return;
+		if (!db || !authStore.isAuthenticated || !authStore.clubId) return;
 		if (!clubId) return;
 		loading = true;
 		errMsg = '';
@@ -85,6 +85,7 @@
 	}
 
 	$effect(() => {
+		if (!db || !authStore.isAuthenticated || !authStore.clubId) return;
 		if (!clubId) return;
 		void loadEntries();
 	});

--- a/src/lib/components/director/RegistrationRosterAssignPanel.svelte
+++ b/src/lib/components/director/RegistrationRosterAssignPanel.svelte
@@ -60,7 +60,7 @@
 	}
 
 	$effect(() => {
-		if (!db || !authStore.isAuthenticated) return;
+		if (!db || !authStore.isAuthenticated || !authStore.clubId) return;
 		if (!clubId) {
 			registrations = [];
 			seasonId = '';

--- a/src/lib/components/director/TeamsTab.svelte
+++ b/src/lib/components/director/TeamsTab.svelte
@@ -59,6 +59,7 @@
 	let pendingInvites = $state(/** @type {PendingInvite[]} */ ([]));
 
 	$effect(() => {
+		if (!db || !authStore.isAuthenticated || !authStore.clubId) return;
 		if (!clubId) { pendingInvites = []; return; }
 		const q = query(
 			collection(db, 'coach_invites'),
@@ -116,7 +117,6 @@
 	// ── Status helpers ────────────────────────────────────────────────────
 	/** @param {{ id: string; coachEmail?: string }} t */
 	function teamStatusLabel(t) {
-    if (!db || !authStore.isAuthenticated) return;
 		if (pendingInviteTeamIds.has(t.id)) return 'PENDING';
 		if (t.coachEmail) return 'ACTIVE';
 		return 'VACANT';

--- a/src/lib/components/director/os/DeploymentCalendar.svelte
+++ b/src/lib/components/director/os/DeploymentCalendar.svelte
@@ -25,7 +25,6 @@
 
 	/** @param {string | undefined} k */
 	function kindBadgeClass(k) {
-    if (!db || !authStore.isAuthenticated) return;
 		const v = typeof k === 'string' ? k.toLowerCase() : '';
 		if (v === 'match') return 'dep-badge dep-badge--match';
 		if (v === 'tournament') return 'dep-badge dep-badge--tournament';
@@ -74,6 +73,7 @@
 	];
 
 	$effect(() => {
+		if (!db || !authStore.isAuthenticated || !authStore.clubId) return;
 		if (!browser || !clubId) {
 			loading = false;
 			rows = [];

--- a/src/lib/components/director/os/DirectorCommandCenter.svelte
+++ b/src/lib/components/director/os/DirectorCommandCenter.svelte
@@ -2,6 +2,7 @@
 	import { browser } from '$app/environment';
 	import { collection, doc, getCountFromServer, getDoc, query, where } from 'firebase/firestore';
 	import { db } from '$lib/firebase.js';
+	import { authStore } from '$lib/stores/auth.svelte.js';
 	import ActionInbox from '$lib/components/shell/ActionInbox.svelte';
 	import DirectorAnalyticsCharts from '$lib/components/shell/DirectorAnalyticsCharts.svelte';
 	import VpcApprovalQueue from '$lib/components/director/os/VpcApprovalQueue.svelte';
@@ -25,6 +26,7 @@
 	let loadingKpis = $state(true);
 
 	$effect(() => {
+		if (!db || !authStore.isAuthenticated || !authStore.clubId) return;
 		if (!browser || !clubId) {
 			kpis = { teams: 0, pendingInvites: 0, activeSeats: 0, seatsLimit: 0 };
 			loadingKpis = false;

--- a/src/lib/components/director/os/EntitlementModule.svelte
+++ b/src/lib/components/director/os/EntitlementModule.svelte
@@ -1,5 +1,6 @@
 <script>
 	import { db } from '$lib/firebase.js';
+	import { authStore } from '$lib/stores/auth.svelte.js';
 	import { doc, onSnapshot } from 'firebase/firestore';
 	import { licenseEntitlementStore } from '$lib/stores/licenseEntitlement.svelte.js';
 
@@ -20,6 +21,7 @@
 	const isTransactionBilled = $derived(licenseEntitlementStore.isTransactionBilled);
 
 	$effect(() => {
+		if (!db || !authStore.isAuthenticated || !authStore.clubId) return;
 		if (!clubId) {
 			loading = false;
 			err = 'No club scope on your profile.';

--- a/src/lib/components/director/os/EventReconciliationModule.svelte
+++ b/src/lib/components/director/os/EventReconciliationModule.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 	import { onDestroy } from 'svelte';
 	import { collection, query, where, onSnapshot } from 'firebase/firestore';
-	import { getActiveDb } from '$lib/firebase';
+	import { db, getActiveDb } from '$lib/firebase.js';
+	import { authStore } from '$lib/stores/auth.svelte.js';
 	import Icon from '$lib/components/ui/Icon.svelte';
 	import type { IconName } from '$lib/icons/registry.js';
 
@@ -35,6 +36,7 @@
 	let unsubscribe: (() => void) | null = null;
 
 	$effect(() => {
+		if (!db || !authStore.isAuthenticated || !authStore.clubId) return;
 		if (!clubId) return;
 		loading = true;
 		const db = getActiveDb();

--- a/src/lib/components/director/os/EventReconciliationModule.svelte
+++ b/src/lib/components/director/os/EventReconciliationModule.svelte
@@ -36,10 +36,11 @@
 	let unsubscribe: (() => void) | null = null;
 
 	$effect(() => {
-		if (!db || !authStore.isAuthenticated || !authStore.clubId) return;
+		const activeDb = getActiveDb();
+		if (!activeDb || !authStore.isAuthenticated || !authStore.clubId) return;
 		if (!clubId) return;
 		loading = true;
-		const db = getActiveDb();
+		const db = activeDb;
 
 		// Listen to all paid tickets for this host club, created today or later.
 		const todayStart = new Date();

--- a/src/lib/components/director/os/FieldOpsModule.svelte
+++ b/src/lib/components/director/os/FieldOpsModule.svelte
@@ -85,6 +85,7 @@
 	);
 
 	$effect(() => {
+		if (!db || !authStore.isAuthenticated || !authStore.clubId) return;
 		if (!browser || !resolvedClubId) {
 			weatherFacilityStatuses = [];
 			return;
@@ -226,6 +227,7 @@
 	});
 
 	$effect(() => {
+		if (!db || !authStore.isAuthenticated || !authStore.clubId) return;
 		if (!resolvedClubId) {
 			fields = [];
 			mapFacilities = [];
@@ -289,6 +291,7 @@
 	});
 
 	$effect(() => {
+		if (!db || !authStore.isAuthenticated || !authStore.clubId) return;
 		if (!fieldId || !scheduleDate) {
 			schedules = [];
 			return;

--- a/src/lib/components/director/os/HotelRebatePanel.svelte
+++ b/src/lib/components/director/os/HotelRebatePanel.svelte
@@ -44,10 +44,11 @@
 	let unsubscribe: (() => void) | null = null;
 
 	$effect(() => {
-		if (!db || !authStore.isAuthenticated || !authStore.clubId) return;
+		const activeDb = getActiveDb();
+		if (!activeDb || !authStore.isAuthenticated || !authStore.clubId) return;
 		if (!clubId) return;
 		loading = true;
-		const db = getActiveDb();
+		const db = activeDb;
 		const q = query(
 			collection(db, 'hotel_rebates'),
 			where('tenantId', '==', clubId),

--- a/src/lib/components/director/os/HotelRebatePanel.svelte
+++ b/src/lib/components/director/os/HotelRebatePanel.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 	import { onDestroy } from 'svelte';
 	import { collection, query, where, orderBy, onSnapshot } from 'firebase/firestore';
-	import { getActiveDb } from '$lib/firebase';
+	import { db, getActiveDb } from '$lib/firebase.js';
+	import { authStore } from '$lib/stores/auth.svelte.js';
 	import Icon from '$lib/components/ui/Icon.svelte';
 	import type { IconName } from '$lib/icons/registry.js';
 
@@ -43,6 +44,7 @@
 	let unsubscribe: (() => void) | null = null;
 
 	$effect(() => {
+		if (!db || !authStore.isAuthenticated || !authStore.clubId) return;
 		if (!clubId) return;
 		loading = true;
 		const db = getActiveDb();

--- a/src/lib/components/director/os/PaymentRecoveryModule.svelte
+++ b/src/lib/components/director/os/PaymentRecoveryModule.svelte
@@ -25,6 +25,7 @@
 	let resolveError = $state('');
 
 	$effect(() => {
+		if (!db || !authStore.isAuthenticated || !authStore.clubId) return;
 		if (!browser || !clubId || !hasScanned) return;
 		loading = true;
 

--- a/src/lib/components/director/os/PendingInvitesList.svelte
+++ b/src/lib/components/director/os/PendingInvitesList.svelte
@@ -12,7 +12,6 @@
 	let err = $state(/** @type {string | null} */ (null));
 
 	function teamLabel(teamId) {
-    if (!db || !authStore.isAuthenticated) return;
 		const t = teamsStore.teams.find((x) => x.id === teamId);
 		return t?.name || teamId;
 	}
@@ -26,6 +25,7 @@
 	}
 
 	$effect(() => {
+		if (!db || !authStore.isAuthenticated || !authStore.clubId) return;
 		if (!clubId) {
 			invites = [];
 			return;

--- a/src/lib/components/director/os/TryoutSessionsPanel.svelte
+++ b/src/lib/components/director/os/TryoutSessionsPanel.svelte
@@ -71,6 +71,7 @@
 	]);
 
 	$effect(() => {
+		if (!db || !authStore.isAuthenticated || !authStore.clubId) return;
 		const pid = programId.trim();
 		if (!pid || !browser) {
 			sessions = [];
@@ -124,6 +125,7 @@
 	});
 
 	$effect(() => {
+		if (!db || !authStore.isAuthenticated || !authStore.clubId) return;
 		const pid = programId.trim();
 		if (!pid || !browser) return;
 		const ref = doc(db, 'tryout_programs', pid);

--- a/src/lib/components/director/os/VpcApprovalQueue.svelte
+++ b/src/lib/components/director/os/VpcApprovalQueue.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { authStore } from '$lib/stores/auth.svelte';
+	import { authStore } from '$lib/stores/auth.svelte.js';
 	import { browser } from '$app/environment';
 	import {
 		collection,
@@ -21,7 +21,7 @@
 	let loadError = $state('');
 
 	$effect(() => {
-		if (!db || !authStore.isAuthenticated) return;
+		if (!db || !authStore.isAuthenticated || !authStore.clubId) return;
 		if (!browser || !clubId) {
 			records = [];
 			loading = false;

--- a/src/lib/stores/auth/facade.svelte.js
+++ b/src/lib/stores/auth/facade.svelte.js
@@ -76,6 +76,7 @@ export function createAuthFacade() {
 		get role() { return sessionState.role; },
 		get tenantId() { return tenantState.tenantId; },
 		get currentTenantId() { return tenantState.currentTenantId; },
+		get clubId() { return tenantState.tenantId || userState.userProfile?.clubId || ''; },
 		get orgId() { return tenantState.orgId; },
 		get cellId() { return tenantState.cellId; },
 		get isCoach() { return sessionState.isCoach; },

--- a/src/routes/(app)/director/+layout.svelte
+++ b/src/routes/(app)/director/+layout.svelte
@@ -6,6 +6,7 @@
 	import '$lib/styles/director-field-ops-map.css';
 	import DirectorReadOnlyBanner from '$lib/components/director/DirectorReadOnlyBanner.svelte';
 	import ReadOnlyUpgradeModal from '$lib/components/director/ReadOnlyUpgradeModal.svelte';
+	import { auth, db } from '$lib/firebase.js';
 	import { authStore } from '$lib/stores/auth.svelte.js';
 	import { licenseEntitlementStore } from '$lib/stores/licenseEntitlement.svelte.js';
 	import { isSubscriptionReadOnly } from '$lib/auth/billing.js';
@@ -29,6 +30,16 @@
 
 	setContext('openReadOnlyUpgrade', () => {
 		upgradeModalOpen = true;
+	});
+
+	// Force client SDK to dump stale cache and fetch fresh Custom Claims payload upon Director session init
+	$effect(() => {
+		if (!db || !authStore.isAuthenticated) return;
+		void auth.currentUser?.getIdToken(true).then(() => {
+			void authStore.refreshClaims();
+		}).catch((err) => {
+			console.warn('[Director OS Layout] Custom token refresh warning:', err);
+		});
 	});
 </script>
 

--- a/src/routes/(app)/director/dashboard/IntakePanopticon.svelte
+++ b/src/routes/(app)/director/dashboard/IntakePanopticon.svelte
@@ -40,7 +40,7 @@
 
   // Firestore real-time listener — exception-only: pending_guardian nodes only
   $effect(() => {
-		if (!db || !authStore.isAuthenticated) return;
+		if (!db || !authStore.isAuthenticated || !authStore.clubId) return;
     if (!browser || !currentClubId) { isLoading = false; return; }
     isLoading = true;
     const q = query(

--- a/src/routes/(app)/director/dashboard/VpcPanopticon.svelte
+++ b/src/routes/(app)/director/dashboard/VpcPanopticon.svelte
@@ -46,7 +46,7 @@
 
   // Real-time Firestore query — exception-only (pending_guardian)
   $effect(() => {
-		if (!db || !authStore.isAuthenticated) return;
+		if (!db || !authStore.isAuthenticated || !authStore.clubId) return;
     if (!browser || !currentClubId) {
       pendingNodes = [];
       isLoading = false;

--- a/src/routes/(app)/director/events/+page.svelte
+++ b/src/routes/(app)/director/events/+page.svelte
@@ -19,7 +19,7 @@
 	const clubId = $derived(authStore.userProfile?.clubId ?? '');
 
 	$effect(() => {
-		if (!authStore.isAuthenticated) return;
+		if (!db || !authStore.isAuthenticated || !authStore.clubId) return;
 		if (!clubId) return;
 		loading = true;
 		const db = getActiveDb();

--- a/src/routes/(app)/director/events/+page.svelte
+++ b/src/routes/(app)/director/events/+page.svelte
@@ -19,10 +19,11 @@
 	const clubId = $derived(authStore.userProfile?.clubId ?? '');
 
 	$effect(() => {
-		if (!db || !authStore.isAuthenticated || !authStore.clubId) return;
+		const activeDb = getActiveDb();
+		if (!activeDb || !authStore.isAuthenticated || !authStore.clubId) return;
 		if (!clubId) return;
 		loading = true;
-		const db = getActiveDb();
+		const db = activeDb;
 		const q = query(
 			collection(db, 'tournament_events'),
 			where('hostClubId', '==', clubId),

--- a/src/routes/(app)/director/events/[eventId]/+page.svelte
+++ b/src/routes/(app)/director/events/[eventId]/+page.svelte
@@ -42,9 +42,10 @@ import { untrack } from 'svelte';
 	let unsubscribe: (() => void) | null = null;
 
 	$effect(() => {
-		if (!db || !authStore.isAuthenticated || !authStore.clubId) return;
+		const activeDb = getActiveDb();
+		if (!activeDb || !authStore.isAuthenticated || !authStore.clubId) return;
 		if (!eventId) return;
-		const db = getActiveDb();
+		const db = activeDb;
 		unsubscribe = onSnapshot(doc(db, 'tournament_events', eventId), (snap) => {
 			if (!snap.exists()) { loading = false; return; }
 			const data = snap.data() as Omit<TournamentEventDoc, 'id'>;

--- a/src/routes/(app)/director/events/[eventId]/+page.svelte
+++ b/src/routes/(app)/director/events/[eventId]/+page.svelte
@@ -42,6 +42,7 @@ import { untrack } from 'svelte';
 	let unsubscribe: (() => void) | null = null;
 
 	$effect(() => {
+		if (!db || !authStore.isAuthenticated || !authStore.clubId) return;
 		if (!eventId) return;
 		const db = getActiveDb();
 		unsubscribe = onSnapshot(doc(db, 'tournament_events', eventId), (snap) => {

--- a/src/routes/(app)/director/exceptions/FailsafeOverride.svelte
+++ b/src/routes/(app)/director/exceptions/FailsafeOverride.svelte
@@ -30,6 +30,7 @@
 
 	// ── Data Loading ──────────────────────────────────────────────────────────
 	$effect(() => {
+		if (!db || !authStore.isAuthenticated || !authStore.clubId) return;
 		if (!isAuthorized) return;
 		const tenantId = authStore.tenantId;
 		if (!tenantId) return;
@@ -37,7 +38,6 @@
 		let cancelled = false;
 
 		async function loadNodes() {
-    if (!db || !authStore.isAuthenticated) return;
 			isLoadingNodes = true;
 			try {
 				const usersRef = collection(db, 'users');

--- a/src/routes/(app)/director/uplinks/+page.svelte
+++ b/src/routes/(app)/director/uplinks/+page.svelte
@@ -51,7 +51,7 @@
 	// Subscribe (and re-subscribe) once club context hydrates — onMount fired too
 	// early when userProfile was not yet loaded, leaving a permanent error state.
 	$effect(() => {
-		if (!db || !authStore.isAuthenticated) return;
+		if (!db || !authStore.isAuthenticated || !authStore.clubId) return;
 		const cid = clubId;
 		if (!cid) {
 			loadError = 'Club context not available.';


### PR DESCRIPTION
Enforces fresh JWT Custom Claims on Director session initialization and adds strict B815 defensive hydration guards (if (!db || !authStore.isAuthenticated || !authStore.clubId) return;) across all Director OS components and routes to eradicate permission errors.

---
*PR created automatically by Jules for task [8016590736804925500](https://jules.google.com/task/8016590736804925500) started by @blueneekone*