### PR TITLE
🔒 [security fix] Restrict team_workouts write access to coaches and directors

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -146,7 +146,8 @@ service cloud.firestore {
     }
 
     match /team_workouts/{workoutId} {
-      allow read, write: if isAuthenticated();
+      allow read: if isAuthenticated();
+      allow write: if isCoach() || isDirector();
 
       match /rsvps/{playerEmail} {
         allow read: if teamWorkoutRsvpReadOk();

--- a/src/lib/security/__tests__/firestoreRulesSprint21.test.ts
+++ b/src/lib/security/__tests__/firestoreRulesSprint21.test.ts
@@ -33,4 +33,14 @@ describe('Sprint 2.1 — Firestore rules structure', () => {
 		expect(consentsBlock).not.toBeNull();
 		expect(consentsBlock![0]).not.toMatch(/allow write: if true/);
 	});
+
+	it('restricts team_workouts write permissions to coaches and directors', () => {
+		expect(RULES).toMatch(/match \/team_workouts\/\{workoutId\}/);
+		expect(RULES).toMatch(
+			/match \/team_workouts\/\{workoutId\}[\s\S]*?allow read: if isAuthenticated\(\);[\s\S]*?allow write: if isCoach\(\) \|\| isDirector\(\);/,
+		);
+		const workoutsBlock = RULES.match(/match \/team_workouts\/\{workoutId\}[\s\S]*?(?=match \/|$)/);
+		expect(workoutsBlock).not.toBeNull();
+		expect(workoutsBlock![0]).not.toMatch(/allow read,\s*write:\s*if\s*isAuthenticated\(\);/);
+	});
 });


### PR DESCRIPTION
🔒 **[security fix] Restrict team_workouts write access to coach/director roles**

🎯 **What:**
Updated `firestore.rules` for `/team_workouts/{workoutId}` to separate read and write access rules. Read access remains available to all authenticated users (`isAuthenticated()`) to allow players, parents, and coaches to view team workouts and schedule events. Write access (create, update, delete) is now restricted to coaches and directors (`isCoach() || isDirector()`).

⚠️ **Risk:**
Previously, any authenticated user (including regular players or unprivileged accounts) could create, modify, or delete team workout documents and schedule entries in `team_workouts`. This could lead to unauthorized schedule tampering, malicious content injection, or event deletion.

🛡️ **Solution:**
- Split `allow read, write: if isAuthenticated();` in `firestore.rules` into explicit read (`isAuthenticated()`) and write (`isCoach() || isDirector()`) conditions.
- Updated security unit test suite in `src/lib/security/__tests__/firestoreRulesSprint21.test.ts` to assert role-gated write access on `team_workouts`.

---
*PR created automatically by Jules for task [1070587787182301784](https://jules.google.com/task/1070587787182301784) started by @blueneekone*