### PR TITLE
🔒 Fix execSync usage in acquisitionPrintMeta.server.js

### DIFF
--- a/src/lib/components/marketing/__tests__/acquisitionPrintMeta.test.ts
+++ b/src/lib/components/marketing/__tests__/acquisitionPrintMeta.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { loadAcquisitionPrintMeta } from '../acquisition/acquisitionPrintMeta.server.js';
+
+describe('loadAcquisitionPrintMeta', () => {
+	const originalEnv = process.env;
+
+	beforeEach(() => {
+		process.env = { ...originalEnv };
+		delete process.env.VITE_COMMIT_SHA;
+		delete process.env.COMMIT_SHA;
+		delete process.env.VERCEL_GIT_COMMIT_SHA;
+	});
+
+	afterEach(() => {
+		process.env = originalEnv;
+	});
+
+	it('returns buildDate formatted as YYYY-MM-DD and non-empty shortSha', () => {
+		const meta = loadAcquisitionPrintMeta();
+		expect(meta.buildDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+		expect(typeof meta.shortSha).toBe('string');
+		expect(meta.shortSha.length).toBeGreaterThan(0);
+	});
+
+	it('prefers environment variable VITE_COMMIT_SHA over git execution', () => {
+		process.env.VITE_COMMIT_SHA = '1234567890abcdef';
+		const meta = loadAcquisitionPrintMeta();
+		expect(meta.shortSha).toBe('1234567');
+	});
+});

--- a/src/lib/components/marketing/acquisition/acquisitionPrintMeta.server.js
+++ b/src/lib/components/marketing/acquisition/acquisitionPrintMeta.server.js
@@ -1,16 +1,27 @@
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 
 /** @returns {{ buildDate: string; shortSha: string }} */
 export function loadAcquisitionPrintMeta() {
-	let shortSha = 'dev';
-	try {
-		shortSha = execSync('git rev-parse --short HEAD', { encoding: 'utf-8' }).trim();
-	} catch {
-		/* not a git checkout */
+	let shortSha =
+		process.env.VITE_COMMIT_SHA ||
+		process.env.COMMIT_SHA ||
+		process.env.VERCEL_GIT_COMMIT_SHA ||
+		'';
+
+	if (shortSha) {
+		shortSha = shortSha.slice(0, 7);
+	} else {
+		try {
+			shortSha = execFileSync('git', ['rev-parse', '--short', 'HEAD'], {
+				encoding: 'utf-8',
+			}).trim();
+		} catch {
+			shortSha = 'dev';
+		}
 	}
 
 	return {
 		buildDate: new Date().toISOString().slice(0, 10),
-		shortSha,
+		shortSha: shortSha || 'dev',
 	};
 }


### PR DESCRIPTION
🎯 What: Replaced use of `execSync` with `execFileSync` and environment variable resolution for commit SHA in `acquisitionPrintMeta.server.js`. Added unit tests in `acquisitionPrintMeta.test.ts`.

⚠️ Risk: Standardizing away `execSync` prevents shell invocation vulnerabilities while guaranteeing safe git metadata extraction or graceful fallback.

🛡️ Solution: Checked `process.env` for commit SHAs (`VITE_COMMIT_SHA`, `COMMIT_SHA`, `VERCEL_GIT_COMMIT_SHA`) first, and used `execFileSync('git', ['rev-parse', '--short', 'HEAD'], { encoding: 'utf-8' })` as a safe fallback without shell invocation.

---
*PR created automatically by Jules for task [10324519944005912557](https://jules.google.com/task/10324519944005912557) started by @blueneekone*