### PR TITLE
🧹 refactor(integrations): throw typed UnknownTargetError in resolveTarget

### DIFF
--- a/functions-integrations/__tests__/resolveTarget.test.js
+++ b/functions-integrations/__tests__/resolveTarget.test.js
@@ -1,0 +1,65 @@
+'use strict';
+
+const { test, describe, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const { resolveTarget, UnknownTargetError } = require('../resolveTarget');
+
+describe('resolveTarget', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.FUNCTION_TARGET;
+    delete process.env.K_SERVICE;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  test('returns empty string when both FUNCTION_TARGET and K_SERVICE are unset', () => {
+    assert.equal(resolveTarget(), '');
+  });
+
+  test('resolves target from FUNCTION_TARGET (exact match)', () => {
+    process.env.FUNCTION_TARGET = 'getSoccerNews';
+    assert.equal(resolveTarget(), 'getSoccerNews');
+  });
+
+  test('resolves target from FUNCTION_TARGET with dot prefix', () => {
+    process.env.FUNCTION_TARGET = 'integrations.processMedia';
+    assert.equal(resolveTarget(), 'processMedia');
+  });
+
+  test('resolves target from FUNCTION_TARGET with hyphen prefix', () => {
+    process.env.FUNCTION_TARGET = 'integrations-ingestRoster';
+    assert.equal(resolveTarget(), 'ingestRoster');
+  });
+
+  test('resolves target from K_SERVICE (lowercase matching)', () => {
+    process.env.K_SERVICE = 'getweatherconditions';
+    assert.equal(resolveTarget(), 'getWeatherConditions');
+  });
+
+  test('prefers FUNCTION_TARGET over K_SERVICE', () => {
+    process.env.FUNCTION_TARGET = 'searchPodcasts';
+    process.env.K_SERVICE = 'getweatherconditions';
+    assert.equal(resolveTarget(), 'searchPodcasts');
+  });
+
+  test('throws UnknownTargetError with target property when target is unknown', () => {
+    process.env.FUNCTION_TARGET = 'unknownExportName';
+
+    assert.throws(
+      () => resolveTarget(),
+      (err) => {
+        assert.ok(err instanceof UnknownTargetError);
+        assert.ok(err instanceof Error);
+        assert.equal(err.name, 'UnknownTargetError');
+        assert.equal(err.target, 'unknownExportName');
+        assert.equal(err.message, 'Unknown FUNCTION_TARGET for integrations: unknownExportName');
+        return true;
+      }
+    );
+  });
+});

--- a/functions-integrations/resolveTarget.js
+++ b/functions-integrations/resolveTarget.js
@@ -83,7 +83,18 @@ function resolveTarget() {
   }
 
   const label = functionTarget || kService;
-  throw new Error(`Unknown FUNCTION_TARGET for integrations: ${label}`);
+  throw new UnknownTargetError(label);
 }
 
-module.exports = {resolveTarget, EXPORT_NAMES, LOWER_TO_EXPORT};
+class UnknownTargetError extends Error {
+  /**
+   * @param {string} target
+   */
+  constructor(target) {
+    super(`Unknown FUNCTION_TARGET for integrations: ${target}`);
+    this.name = 'UnknownTargetError';
+    this.target = target;
+  }
+}
+
+module.exports = {resolveTarget, EXPORT_NAMES, LOWER_TO_EXPORT, UnknownTargetError};


### PR DESCRIPTION
🧹 Code Health Improvement: Throwing raw Error without specific type in resolveTarget.js

🎯 What:
Replaced raw Error thrown when an unknown target is encountered in `functions-integrations/resolveTarget.js` with a custom `UnknownTargetError` class that extends `Error` and attaches the target identifier as a property (`err.target`).

💡 Why:
Using a dedicated `UnknownTargetError` improves error classification, inspectability, and maintainability across functions-integrations.

✅ Verification:
- Added unit tests in `functions-integrations/__tests__/resolveTarget.test.js` validating all target resolution rules and asserting `UnknownTargetError` thrown behavior.
- Confirmed all unit tests pass with Node native test runner (`node --test`).
- Obtained approval via code review.

---
*PR created automatically by Jules for task [12134553414059391500](https://jules.google.com/task/12134553414059391500) started by @blueneekone*