### PR TITLE
🔒 [security fix] Insecure Firestore Rule: Restrict Tryout Programs to Club Staff & Tenant Isolation

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -259,19 +259,34 @@ service cloud.firestore {
       allow create, update, delete: if false;
     }
 
+    function isClubStaff() {
+      return isAuthenticated() && (
+        request.auth.token.role == 'director' ||
+        request.auth.token.role == 'coach' ||
+        request.auth.token.role == 'registrar' ||
+        isGlobalAdmin()
+      );
+    }
+
     match /tryout_programs/{programId} {
-      allow read, write: if isAuthenticated();
+      allow read: if isGlobalAdmin() || (isClubStaff() && request.auth.token.clubId != null && resource.data.clubId == request.auth.token.clubId);
+      allow write: if isGlobalAdmin();
+
       match /registrations/{registrationId} {
-        allow read, write: if isAuthenticated();
+        allow read: if isGlobalAdmin() || (isClubStaff() && request.auth.token.clubId != null && get(/databases/$(database)/documents/tryout_programs/$(programId)).data.clubId == request.auth.token.clubId);
+        allow write: if isGlobalAdmin();
       }
       match /sessions/{sessionId} {
-        allow read, write: if isAuthenticated();
+        allow read: if isGlobalAdmin() || (isClubStaff() && request.auth.token.clubId != null && get(/databases/$(database)/documents/tryout_programs/$(programId)).data.clubId == request.auth.token.clubId);
+        allow write: if isGlobalAdmin();
       }
       match /evaluations/{registrationId} {
-        allow read, write: if isAuthenticated();
+        allow read: if isGlobalAdmin() || (isClubStaff() && request.auth.token.clubId != null && get(/databases/$(database)/documents/tryout_programs/$(programId)).data.clubId == request.auth.token.clubId);
+        allow write: if isGlobalAdmin();
       }
       match /comms/{commId} {
-        allow read, write: if isAuthenticated();
+        allow read: if isGlobalAdmin() || (isClubStaff() && request.auth.token.clubId != null && get(/databases/$(database)/documents/tryout_programs/$(programId)).data.clubId == request.auth.token.clubId);
+        allow write: if isGlobalAdmin();
       }
     }
 

--- a/src/lib/security/__tests__/tryoutProgramsSecurityRules.test.ts
+++ b/src/lib/security/__tests__/tryoutProgramsSecurityRules.test.ts
@@ -1,0 +1,48 @@
+/**
+ * tryoutProgramsSecurityRules.test.ts — Structural validation of tryout_programs security rules
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const RULES = readFileSync(resolve('firestore.rules'), 'utf8');
+
+describe('Tryout Programs Security Rules Structure', () => {
+	it('defines isClubStaff helper checking director, coach, registrar, and global admin roles', () => {
+		expect(RULES).toMatch(/function isClubStaff\(\)/);
+		expect(RULES).toMatch(/request\.auth\.token\.role == 'director'/);
+		expect(RULES).toMatch(/request\.auth\.token\.role == 'coach'/);
+		expect(RULES).toMatch(/request\.auth\.token\.role == 'registrar'/);
+	});
+
+	it('gates read access to tryout_programs with clubId scoping and isClubStaff or isGlobalAdmin', () => {
+		const tryoutsBlock = RULES.match(/match \/tryout_programs\/\{programId\}[\s\S]*?(?=match \/club_playbooks|$)/);
+		expect(tryoutsBlock).not.toBeNull();
+		const block = tryoutsBlock![0];
+
+		expect(block).toMatch(/allow read:\s*if\s*isGlobalAdmin\(\)\s*\|\|\s*\(isClubStaff\(\)\s*&&\s*request\.auth\.token\.clubId != null\s*&&\s*resource\.data\.clubId == request\.auth\.token\.clubId\);/);
+	});
+
+	it('restricts direct client writes on tryout_programs to isGlobalAdmin', () => {
+		const tryoutsBlock = RULES.match(/match \/tryout_programs\/\{programId\}[\s\S]*?(?=match \/club_playbooks|$)/);
+		expect(tryoutsBlock).not.toBeNull();
+		const block = tryoutsBlock![0];
+
+		expect(block).toMatch(/allow write:\s*if\s*isGlobalAdmin\(\);/);
+	});
+
+	it('gates subcollections (registrations, sessions, evaluations, comms) to matching club staff or isGlobalAdmin', () => {
+		const tryoutsBlock = RULES.match(/match \/tryout_programs\/\{programId\}[\s\S]*?(?=match \/club_playbooks|$)/);
+		expect(tryoutsBlock).not.toBeNull();
+		const block = tryoutsBlock![0];
+
+		expect(block).toMatch(/match \/registrations\/\{registrationId\}/);
+		expect(block).toMatch(/match \/sessions\/\{sessionId\}/);
+		expect(block).toMatch(/match \/evaluations\/\{registrationId\}/);
+		expect(block).toMatch(/match \/comms\/\{commId\}/);
+
+		// Check subcollection read lookup
+		expect(block).toMatch(/get\(\/databases\/\$\(database\)\/documents\/tryout_programs\/\$\(programId\)\)\.data\.clubId == request\.auth\.token\.clubId/);
+	});
+});


### PR DESCRIPTION
🔒 **What:** Fixed an insecure Firestore rule on `/tryout_programs/{programId}` and its subcollections (`registrations`, `sessions`, `evaluations`, `comms`) that previously allowed open read and write access to any authenticated user.

⚠️ **Risk:** Any authenticated user could previously read, overwrite, or delete sensitive tryout program records, registration details, evaluation scores, and communication logs across all club tenants without authorization.

🛡️ **Solution:**
1. Introduced helper `isClubStaff()` checking for director, coach, registrar, or global admin roles.
2. Enforced tenant isolation on `/tryout_programs/{programId}` reads by checking `request.auth.token.clubId == resource.data.clubId`.
3. Restricted read access on subcollections (`/registrations`, `/sessions`, `/evaluations`, `/comms`) to matching club staff via parent document lookup `get(/databases/$(database)/documents/tryout_programs/$(programId)).data.clubId == request.auth.token.clubId`.
4. Restricted direct client writes on `tryout_programs` and subcollections to `isGlobalAdmin()`, ensuring all tryout mutations execute securely through backend Cloud Functions callables (`upsertTryoutProgram`, `registerForTryout`, etc.).
5. Added unit test suite `src/lib/security/__tests__/tryoutProgramsSecurityRules.test.ts` to validate rule structure.

---
*PR created automatically by Jules for task [9261801124536870106](https://jules.google.com/task/9261801124536870106) started by @blueneekone*