### PR TITLE
🧹 Remove unused goto import in player dashboard

### DIFF
--- a/src/routes/(app)/player/dashboard/+page.svelte
+++ b/src/routes/(app)/player/dashboard/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { browser } from '$app/environment';
-	import { goto } from '$app/navigation';
 	import Icon from '$lib/components/ui/Icon.svelte';
 	import type { IconName } from '$lib/icons/registry.js';
 	import { doc, getDoc, getDocs, onSnapshot, updateDoc, collection, query, where, orderBy, limit } from 'firebase/firestore';


### PR DESCRIPTION
🎯 **What:** Removed unused `goto` import from `src/routes/(app)/player/dashboard/+page.svelte`.
💡 **Why:** To improve code health, remove dead code, and clear linter warnings. This small change enhances readability and codebase hygiene.
✅ **Verification:** Verified via `pnpm run check` that no svelte-check errors were introduced. E2E and unit test suites passing via `pnpm run test`. Code reviewed and approved.
✨ **Result:** A cleaner player dashboard component without unnecessary imports.

---
*PR created automatically by Jules for task [11787116529493869203](https://jules.google.com/task/11787116529493869203) started by @blueneekone*