### PR TITLE
🧹 Remove unused `db` import in parent dashboard

### DIFF
--- a/src/routes/(app)/parent/dashboard/+page.svelte
+++ b/src/routes/(app)/parent/dashboard/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { untrack } from 'svelte';
 	import { authStore } from '$lib/stores/auth.svelte.js';
-	import { db } from '$lib/firebase.js';
 	import CarRideHome from '$lib/components/compliance/CarRideHome.svelte';
 	import CoOpArena from '$lib/components/parent/co-op/CoOpArena.svelte';
 	import BountyTerminal from '$lib/components/parent/co-op/BountyTerminal.svelte';


### PR DESCRIPTION
🎯 **What:** Removed the unused `db` import from `src/routes/(app)/parent/dashboard/+page.svelte`.
💡 **Why:** Cleans up dead code, avoids confusing future developers who might think `db` is used, and resolves a minor static analysis warning.
✅ **Verification:** Verified via `npm run check` and running the test suite via `npm run test` which both passed successfully.
✨ **Result:** Improved code health and maintainability of the parent dashboard layout file.

---
*PR created automatically by Jules for task [12885483919594264936](https://jules.google.com/task/12885483919594264936) started by @blueneekone*