### PR TITLE
🧹 Remove unused `untrack` import in directory page

### DIFF
--- a/src/routes/(app)/directory/+page.svelte
+++ b/src/routes/(app)/directory/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-    import { untrack } from 'svelte';
     import { db } from '$lib/firebase/config';
     import { authStore } from '$lib/stores/auth.svelte.js';
     import { collection, query, where, getDocs } from 'firebase/firestore';


### PR DESCRIPTION
🎯 **What:** Removed the unused `untrack` import from `src/routes/(app)/directory/+page.svelte`.
💡 **Why:** Unused imports clutter the codebase and can cause confusion. Removing it improves maintainability and readability.
✅ **Verification:** Ran `pnpm run check` and `pnpm run test` to verify that there are no formatting, linting, or testing regressions. All checks passed successfully.
✨ **Result:** The codebase is cleaner, and code health is improved.

---
*PR created automatically by Jules for task [5748744952664629744](https://jules.google.com/task/5748744952664629744) started by @blueneekone*