### PR TITLE
🧪 Add tests for pricing types and helpers

### DIFF
--- a/src/lib/types/__tests__/pricing.test.ts
+++ b/src/lib/types/__tests__/pricing.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import {
+	DEFAULT_POLICY_ID,
+	BP_DIVISOR,
+	bpToPercentLabel,
+	centsToUsd
+} from '../pricing.js';
+
+describe('pricing types', () => {
+	describe('constants', () => {
+		it('DEFAULT_POLICY_ID is default-v1', () => {
+			expect(DEFAULT_POLICY_ID).toBe('default-v1');
+		});
+
+		it('BP_DIVISOR is 10000', () => {
+			expect(BP_DIVISOR).toBe(10000);
+		});
+	});
+
+	describe('bpToPercentLabel', () => {
+		it('converts positive basis points to percent label', () => {
+			expect(bpToPercentLabel(100)).toBe('1.00%');
+			expect(bpToPercentLabel(250)).toBe('2.50%');
+			expect(bpToPercentLabel(10000)).toBe('100.00%');
+		});
+
+		it('converts negative basis points to percent label', () => {
+			expect(bpToPercentLabel(-100)).toBe('-1.00%');
+			expect(bpToPercentLabel(-7000)).toBe('-70.00%');
+		});
+
+		it('handles zero basis points', () => {
+			expect(bpToPercentLabel(0)).toBe('0.00%');
+		});
+	});
+
+	describe('centsToUsd', () => {
+		it('converts positive cents to USD label', () => {
+			expect(centsToUsd(12345)).toBe('$123.45');
+			expect(centsToUsd(5)).toBe('$0.05');
+			expect(centsToUsd(100)).toBe('$1.00');
+			expect(centsToUsd(150000)).toBe('$1,500.00');
+		});
+
+		it('converts negative cents to USD label', () => {
+			expect(centsToUsd(-12345)).toBe('-$123.45');
+			expect(centsToUsd(-5)).toBe('-$0.05');
+			expect(centsToUsd(-100)).toBe('-$1.00');
+			expect(centsToUsd(-150000)).toBe('-$1,500.00');
+		});
+
+		it('handles zero cents', () => {
+			expect(centsToUsd(0)).toBe('$0.00');
+		});
+	});
+});


### PR DESCRIPTION
🎯 **What:** Missing test file for `src/lib/types/pricing.ts`.

📊 **Coverage:** Constants (`DEFAULT_POLICY_ID`, `BP_DIVISOR`) and helper functions (`bpToPercentLabel` and `centsToUsd`).

✨ **Result:** The improvement in test coverage.

---
*PR created automatically by Jules for task [7784575962192753478](https://jules.google.com/task/7784575962192753478) started by @blueneekone*