### PR TITLE
fix(scripts): add onAdvance prop mapping to platform healer modal updates

### DIFF
--- a/local_platform_healer.py
+++ b/local_platform_healer.py
@@ -192,23 +192,26 @@ def heal_platform_logic(root):
                 # Svelte 5 fix: Instead of invoking a potentially unmapped 'onClose()' or 'onAdvance()' prop,
                 # we force the cancel button to directly mutate the bindable 'show' property.
                 # This naturally propagates back to the parent component and shuts the modal!
-                if "onclick={onClose}" in content or "onclick={() => onClose()}" in content:
-                    content = re.sub(
-                        r'onclick=\{onClose\}',
-                        'onclick={() => { show = false; }}',
-                        content
-                    )
-                    content = re.sub(
-                        r'onclick=\{\(\)\s*=>\s*onClose\(\)\}',
-                        'onclick={() => { show = false; }}',
-                        content
-                    )
-                    
+                for prop in ['onClose', 'onAdvance']:
+                    if f"onclick={{{prop}}}" in content or f"onclick={{() => {prop}()}}" in content:
+                        content = re.sub(
+                            f'onclick=\\{{{prop}\\}}',
+                            'onclick={() => { show = false; }}',
+                            content
+                        )
+                        content = re.sub(
+                            f'onclick=\\{{\\(\\)\\s*=>\\s*{prop}\\(\\)\\}}',
+                            'onclick={() => { show = false; }}',
+                            content
+                        )
+
                 # Ensure the modal is strictly encapsulated and doesn't crash on unmapped callback props
-                if "let { show = $bindable()" in content and "onClose" in content:
-                    # Strip onClose out of props destructuring
-                    content = content.replace(", onClose", "")
-                    content = content.replace("onClose,", "")
+                if "let { show = $bindable()" in content:
+                    for prop in ['onClose', 'onAdvance']:
+                        if prop in content:
+                            # Strip prop out of props destructuring
+                            content = content.replace(f", {prop}", "")
+                            content = content.replace(f"{prop},", "")
                     
                 if content != original:
                     with open(path, 'w', encoding='utf-8') as f:


### PR DESCRIPTION
This patch dynamically implements Svelte 5 fix refactors for the `onAdvance` prop alongside the previously hardcoded `onClose` prop in `local_platform_healer.py`. It uses python f-strings to appropriately match and safely replace the click bindings to automatically mute the `show` property. Unmapped properties destructuring bindings in Svelte `$props()` definitions are also safely updated.

---
*PR created automatically by Jules for task [16617995263253021611](https://jules.google.com/task/16617995263253021611) started by @blueneekone*