### PR TITLE
🔒 fix hardcoded AES_SECRET_KEY fallback

### DIFF
--- a/functions-compliance/src/domains/complianceOps.js
+++ b/functions-compliance/src/domains/complianceOps.js
@@ -1503,7 +1503,10 @@ const crypto = require('crypto');
 
 function encryptString(text) {
   if (!text) return '';
-  const secretKey = process.env.AES_SECRET_KEY || '12345678901234567890123456789012';
+  const secretKey = process.env.AES_SECRET_KEY;
+  if (!secretKey) {
+    throw new Error('AES_SECRET_KEY environment variable is missing.');
+  }
   const iv = crypto.randomBytes(16);
   const cipher = crypto.createCipheriv('aes-256-cbc', Buffer.from(secretKey), iv);
   let encrypted = cipher.update(text, 'utf-8', 'hex');

--- a/functions/src/domains/complianceOps.js
+++ b/functions/src/domains/complianceOps.js
@@ -1503,7 +1503,10 @@ const crypto = require('crypto');
 
 function encryptString(text) {
   if (!text) return '';
-  const secretKey = process.env.AES_SECRET_KEY || '12345678901234567890123456789012';
+  const secretKey = process.env.AES_SECRET_KEY;
+  if (!secretKey) {
+    throw new Error('AES_SECRET_KEY environment variable is missing.');
+  }
   const iv = crypto.randomBytes(16);
   const cipher = crypto.createCipheriv('aes-256-cbc', Buffer.from(secretKey), iv);
   let encrypted = cipher.update(text, 'utf-8', 'hex');


### PR DESCRIPTION
Fixes a security vulnerability where a hardcoded fallback string was used as the AES secret key for `encryptString` in `complianceOps.js`. The fix removes the hardcoded string and explicitly throws an error if the `process.env.AES_SECRET_KEY` environment variable is missing, adhering to fail-secure principles. Bundled changes into `functions-compliance`.

---
*PR created automatically by Jules for task [9395537061654653448](https://jules.google.com/task/9395537061654653448) started by @blueneekone*