### PR TITLE
🧹 Remove unnecessary try/catch from AdvancedMarkerElement title assignment

### DIFF
--- a/src/lib/components/field-ops/FacilityDrawingMap.svelte
+++ b/src/lib/components/field-ops/FacilityDrawingMap.svelte
@@ -307,11 +307,7 @@ type ExtendedAdvancedMarkerElement = any & { __facilityMarkerIndex?: number };
 		const refs = facilityDrawRefs;
 		const marker = refs?.drawnMarkers[idx];
 		if (marker) {
-			try {
-				marker.title = trimmed || 'Marker';
-			} catch {
-				/* ignore */
-			}
+			marker.title = trimmed || 'Marker';
 		}
 	}
 


### PR DESCRIPTION
🎯 **What:** Removed the `try...catch` wrapper and its `/* ignore */` comment around `marker.title = trimmed || 'Marker';` inside `FacilityDrawingMap.svelte`.
💡 **Why:** `AdvancedMarkerElement` has replaced the deprecated `google.maps.Marker`. Setting the `title` property on the `AdvancedMarkerElement` is a standard operation that doesn't throw under normal usage, making the legacy `try/catch` block unnecessary and a source of confusion.
✅ **Verification:** Visually inspected the code change, and ran the full `pnpm run check` and `pnpm run test` suites to verify that this cleanup introduces no regressions and preserves functionality.
✨ **Result:** Cleaner and more straightforward marker label assignment logic.

---
*PR created automatically by Jules for task [4196026894138176095](https://jules.google.com/task/4196026894138176095) started by @blueneekone*