### PR TITLE
🔒 Fix overly permissive access to workout logs

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -233,7 +233,10 @@ service cloud.firestore {
 
     // Workout logs, physio reports, and training data — authenticated users
     match /workout_logs/{logId} {
-      allow read, write: if isAuthenticated();
+      allow read: if isAuthenticated() && (isGlobalAdmin() || isDirector() || isCoach() || resource == null || (('playerId' in resource.data) && resource.data.playerId == request.auth.uid) || (('playerUid' in resource.data) && resource.data.playerUid == request.auth.uid));
+      allow create: if isAuthenticated() && ((('playerId' in request.resource.data) && request.resource.data.playerId == request.auth.uid) || (('playerUid' in request.resource.data) && request.resource.data.playerUid == request.auth.uid) || isGlobalAdmin() || isDirector() || isCoach());
+      allow update: if isAuthenticated() && ((('playerId' in resource.data) && resource.data.playerId == request.auth.uid) || (('playerUid' in resource.data) && resource.data.playerUid == request.auth.uid) || isGlobalAdmin() || isDirector() || isCoach()) && (!('playerId' in request.resource.data) || request.resource.data.playerId == request.auth.uid || isGlobalAdmin() || isDirector() || isCoach()) && (!('playerUid' in request.resource.data) || request.resource.data.playerUid == request.auth.uid || isGlobalAdmin() || isDirector() || isCoach());
+      allow delete: if isAuthenticated() && ((('playerId' in resource.data) && resource.data.playerId == request.auth.uid) || (('playerUid' in resource.data) && resource.data.playerUid == request.auth.uid) || isGlobalAdmin() || isDirector() || isCoach());
     }
     match /grit_awards/{awardId} {
       allow read: if isAuthenticated();

--- a/src/lib/security/__tests__/firestoreRulesWorkoutLogs.test.ts
+++ b/src/lib/security/__tests__/firestoreRulesWorkoutLogs.test.ts
@@ -1,0 +1,168 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import {
+	assertFails,
+	assertSucceeds,
+	initializeTestEnvironment,
+	type RulesTestEnvironment,
+} from '@firebase/rules-unit-testing';
+import { doc, getDoc, setDoc, deleteDoc } from 'firebase/firestore';
+import { afterAll, beforeAll, beforeEach, describe, it } from 'vitest';
+
+const RULES = readFileSync(resolve('firestore.rules'), 'utf8');
+const PROJECT = 'sst-sprint-workout-logs';
+const FIRESTORE_HOST = process.env.FIRESTORE_EMULATOR_HOST?.split(':')[0] ?? '127.0.0.1';
+const FIRESTORE_PORT = Number(process.env.FIRESTORE_EMULATOR_HOST?.split(':')[1] ?? 8080);
+
+function token(overrides: Record<string, unknown>) {
+	return {
+		email: 'actor@test.com',
+		role: 'player',
+		clubId: null,
+		teamId: null,
+		...overrides,
+	};
+}
+
+describe.skipIf(!process.env.FIRESTORE_EMULATOR_HOST)(
+	'Workout Logs Security Rules (emulator)',
+	() => {
+	let env: RulesTestEnvironment;
+
+	beforeAll(async () => {
+		env = await initializeTestEnvironment({
+			projectId: PROJECT,
+			firestore: {
+				rules: RULES,
+				host: FIRESTORE_HOST,
+				port: FIRESTORE_PORT,
+			},
+		});
+	});
+
+	beforeEach(async () => {
+		await env.clearFirestore();
+		await env.withSecurityRulesDisabled(async (context) => {
+			const db = context.firestore();
+			await setDoc(doc(db, 'workout_logs/log1'), {
+				playerId: 'player1-uid',
+			});
+			await setDoc(doc(db, 'workout_logs/log2'), {
+				playerUid: 'player2-uid',
+			});
+		});
+	});
+
+	afterAll(async () => {
+		await env.cleanup();
+	});
+
+	it('player can read their own workout log', async () => {
+		const db = env
+			.authenticatedContext('player1-uid', token({
+				email: 'player1@test.com',
+				role: 'player',
+			}))
+			.firestore();
+		await assertSucceeds(getDoc(doc(db, 'workout_logs/log1')));
+	});
+
+	it('player cannot read another player\'s workout log', async () => {
+		const db = env
+			.authenticatedContext('player2-uid', token({
+				email: 'player2@test.com',
+				role: 'player',
+			}))
+			.firestore();
+		await assertFails(getDoc(doc(db, 'workout_logs/log1')));
+	});
+
+	it('global admin can read any workout log', async () => {
+	    const db = env
+			.authenticatedContext('admin-uid', token({
+				email: 'admin@test.com',
+				role: 'global_admin',
+			}))
+			.firestore();
+		await assertSucceeds(getDoc(doc(db, 'workout_logs/log1')));
+	});
+
+	it('coach can read any workout log', async () => {
+	    const db = env
+			.authenticatedContext('coach-uid', token({
+				email: 'coach@test.com',
+				role: 'coach',
+			}))
+			.firestore();
+		await assertSucceeds(getDoc(doc(db, 'workout_logs/log1')));
+	});
+
+	it('player can create their own workout log', async () => {
+	    const db = env
+			.authenticatedContext('player3-uid', token({
+				email: 'player3@test.com',
+				role: 'player',
+			}))
+			.firestore();
+		await assertSucceeds(setDoc(doc(db, 'workout_logs/log3'), {
+		    playerId: 'player3-uid'
+		}));
+	});
+
+	it('player cannot create workout log for another player', async () => {
+	    const db = env
+			.authenticatedContext('player3-uid', token({
+				email: 'player3@test.com',
+				role: 'player',
+			}))
+			.firestore();
+		await assertFails(setDoc(doc(db, 'workout_logs/log3'), {
+		    playerId: 'player1-uid'
+		}));
+	});
+
+	it('player can delete their own workout log', async () => {
+	    const db = env
+			.authenticatedContext('player1-uid', token({
+				email: 'player1@test.com',
+				role: 'player',
+			}))
+			.firestore();
+		await assertSucceeds(deleteDoc(doc(db, 'workout_logs/log1')));
+	});
+
+	it('player cannot delete another player\'s workout log', async () => {
+	    const db = env
+			.authenticatedContext('player1-uid', token({
+				email: 'player1@test.com',
+				role: 'player',
+			}))
+			.firestore();
+		await assertFails(deleteDoc(doc(db, 'workout_logs/log2')));
+	});
+
+	it('player cannot update another player\'s workout log', async () => {
+	    const db = env
+			.authenticatedContext('player1-uid', token({
+				email: 'player1@test.com',
+				role: 'player',
+			}))
+			.firestore();
+		await assertFails(setDoc(doc(db, 'workout_logs/log2'), {
+		    playerUid: 'player2-uid',
+			someUpdate: true
+		}, { merge: true }));
+	});
+
+	it('player cannot transfer ownership of their workout log', async () => {
+	    const db = env
+			.authenticatedContext('player1-uid', token({
+				email: 'player1@test.com',
+				role: 'player',
+			}))
+			.firestore();
+		await assertFails(setDoc(doc(db, 'workout_logs/log1'), {
+		    playerId: 'player2-uid'
+		}, { merge: true }));
+	});
+});

--- a/src/lib/security/__tests__/firestoreRulesWorkoutLogs.test.ts.orig
+++ b/src/lib/security/__tests__/firestoreRulesWorkoutLogs.test.ts.orig
@@ -1,0 +1,168 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import {
+	assertFails,
+	assertSucceeds,
+	initializeTestEnvironment,
+	type RulesTestEnvironment,
+} from '@firebase/rules-unit-testing';
+import { doc, getDoc, setDoc, deleteDoc } from 'firebase/firestore';
+import { afterAll, beforeAll, beforeEach, describe, it } from 'vitest';
+
+const RULES = readFileSync(resolve('firestore.rules'), 'utf8');
+const PROJECT = 'sst-sprint-workout-logs';
+const FIRESTORE_HOST = process.env.FIRESTORE_EMULATOR_HOST?.split(':')[0] ?? '127.0.0.1';
+const FIRESTORE_PORT = Number(process.env.FIRESTORE_EMULATOR_HOST?.split(':')[1] ?? 8080);
+
+function token(overrides: Record<string, unknown>) {
+	return {
+		email: 'actor@test.com',
+		role: 'player',
+		clubId: null,
+		teamId: null,
+		...overrides,
+	};
+}
+
+describe.skipIf(!process.env.FIRESTORE_EMULATOR_HOST)(
+	'Workout Logs Security Rules (emulator)',
+	() => {
+	let env: RulesTestEnvironment;
+
+	beforeAll(async () => {
+		env = await initializeTestEnvironment({
+			projectId: PROJECT,
+			firestore: {
+				rules: RULES,
+				host: FIRESTORE_HOST,
+				port: FIRESTORE_PORT,
+			},
+		});
+	});
+
+	beforeEach(async () => {
+		await env.clearFirestore();
+		await env.withSecurityRulesDisabled(async (context) => {
+			const db = context.firestore();
+			await setDoc(doc(db, 'workout_logs/log1'), {
+				playerId: 'player1-uid',
+			});
+			await setDoc(doc(db, 'workout_logs/log2'), {
+				playerUid: 'player2-uid',
+			});
+		});
+	});
+
+	afterAll(async () => {
+		await env.cleanup();
+	});
+
+	it('player can read their own workout log', async () => {
+		const db = env
+			.authenticatedContext('player1-uid', token({
+				email: 'player1@test.com',
+				role: 'player',
+			}))
+			.firestore();
+		await assertSucceeds(getDoc(doc(db, 'workout_logs/log1')));
+	});
+
+	it('player cannot read another player\'s workout log', async () => {
+		const db = env
+			.authenticatedContext('player2-uid', token({
+				email: 'player2@test.com',
+				role: 'player',
+			}))
+			.firestore();
+		await assertFails(getDoc(doc(db, 'workout_logs/log1')));
+	});
+
+	it('global admin can read any workout log', async () => {
+	    const db = env
+			.authenticatedContext('admin-uid', token({
+				email: 'admin@test.com',
+				role: 'global_admin',
+			}))
+			.firestore();
+		await assertSucceeds(getDoc(doc(db, 'workout_logs/log1')));
+	});
+
+	it('coach can read any workout log', async () => {
+	    const db = env
+			.authenticatedContext('coach-uid', token({
+				email: 'coach@test.com',
+				role: 'coach',
+			}))
+			.firestore();
+		await assertSucceeds(getDoc(doc(db, 'workout_logs/log1')));
+	});
+
+	it('player can create their own workout log', async () => {
+	    const db = env
+			.authenticatedContext('player3-uid', token({
+				email: 'player3@test.com',
+				role: 'player',
+			}))
+			.firestore();
+		await assertSucceeds(setDoc(doc(db, 'workout_logs/log3'), {
+		    playerId: 'player3-uid'
+		}));
+	});
+
+	it('player cannot create workout log for another player', async () => {
+	    const db = env
+			.authenticatedContext('player3-uid', token({
+				email: 'player3@test.com',
+				role: 'player',
+			}))
+			.firestore();
+		await assertFails(setDoc(doc(db, 'workout_logs/log3'), {
+		    playerId: 'player1-uid'
+		}));
+	});
+
+	it('player can delete their own workout log', async () => {
+	    const db = env
+			.authenticatedContext('player1-uid', token({
+				email: 'player1@test.com',
+				role: 'player',
+			}))
+			.firestore();
+		await assertSucceeds(deleteDoc(doc(db, 'workout_logs/log1')));
+	});
+
+	it('player cannot delete another player\'s workout log', async () => {
+	    const db = env
+			.authenticatedContext('player1-uid', token({
+				email: 'player1@test.com',
+				role: 'player',
+			}))
+			.firestore();
+		await assertFails(deleteDoc(doc(db, 'workout_logs/log2')));
+	});
+});
+
+	it('player cannot update another player\'s workout log', async () => {
+	    const db = env
+			.authenticatedContext('player1-uid', token({
+				email: 'player1@test.com',
+				role: 'player',
+			}))
+			.firestore();
+		await assertFails(setDoc(doc(db, 'workout_logs/log2'), {
+		    playerUid: 'player2-uid',
+			someUpdate: true
+		}, { merge: true }));
+	});
+
+	it('player cannot transfer ownership of their workout log', async () => {
+	    const db = env
+			.authenticatedContext('player1-uid', token({
+				email: 'player1@test.com',
+				role: 'player',
+			}))
+			.firestore();
+		await assertFails(setDoc(doc(db, 'workout_logs/log1'), {
+		    playerId: 'player2-uid'
+		}, { merge: true }));
+	});


### PR DESCRIPTION
🎯 **What:** The `firestore.rules` configuration had an overly permissive rule for the `/workout_logs/{logId}` collection (`allow read, write: if isAuthenticated();`), meaning any authenticated user could read or modify any other user's workout logs.
⚠️ **Risk:** This was a major data exposure and integrity vulnerability. Malicious or curious users could have accessed the private training data, physio reports, and workout logs of other players, or worse, deleted or modified them, compromising the platform's core data integrity.
🛡️ **Solution:** The overly permissive rule was replaced with granular access controls. Regular users can now only perform CRUD operations on workout logs where the `playerId` or `playerUid` field matches their own `request.auth.uid`. To ensure backward compatibility, both `playerId` and `playerUid` are checked using `'playerId' in resource.data`. Authorized roles (`global_admin`, `director`, `coach`) retain read/write access to facilitate club management. Additionally, a new test suite was added (`firestoreRulesWorkoutLogs.test.ts`) to validate these rules against the emulator.

---
*PR created automatically by Jules for task [1650845846062260540](https://jules.google.com/task/1650845846062260540) started by @blueneekone*