### PR TITLE
🧪 test: add operative avatar seed normalizer unit tests

### DIFF
--- a/src/lib/avatars/__tests__/operativeAvatar.test.ts
+++ b/src/lib/avatars/__tests__/operativeAvatar.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeOperativeAvatarSeed } from '../operativeAvatar.js';
+
+describe('normalizeOperativeAvatarSeed', () => {
+	it('returns "operative" for undefined/null input', () => {
+		expect(normalizeOperativeAvatarSeed(undefined)).toBe('operative');
+		expect(normalizeOperativeAvatarSeed(null)).toBe('operative');
+	});
+
+	it('returns "operative" for empty or whitespace strings', () => {
+		expect(normalizeOperativeAvatarSeed('')).toBe('operative');
+		expect(normalizeOperativeAvatarSeed('   ')).toBe('operative');
+		expect(normalizeOperativeAvatarSeed('\t\n')).toBe('operative');
+	});
+
+	it('preserves valid short strings', () => {
+		expect(normalizeOperativeAvatarSeed('hello')).toBe('hello');
+		expect(normalizeOperativeAvatarSeed('test-seed-123')).toBe('test-seed-123');
+	});
+
+	it('stringifies non-string inputs', () => {
+		expect(normalizeOperativeAvatarSeed(123)).toBe('123');
+		expect(normalizeOperativeAvatarSeed(true)).toBe('true');
+		expect(normalizeOperativeAvatarSeed(false)).toBe('false');
+		expect(normalizeOperativeAvatarSeed({})).toBe('[object Object]');
+	});
+
+	it('truncates strings longer than 128 characters', () => {
+		const longString = 'a'.repeat(200);
+		const result = normalizeOperativeAvatarSeed(longString);
+		expect(result).toHaveLength(128);
+		expect(result).toBe('a'.repeat(128));
+	});
+
+	it('trims whitespace before truncating', () => {
+		const longString = '  ' + 'a'.repeat(150) + '  ';
+		const result = normalizeOperativeAvatarSeed(longString);
+		expect(result).toHaveLength(128);
+		expect(result).toBe('a'.repeat(128));
+	});
+});


### PR DESCRIPTION
🎯 **What:** Adds missing unit tests for `normalizeOperativeAvatarSeed` string utility inside `operativeAvatar.js`.
📊 **Coverage:** The tests cover undefined/null inputs, empty strings, whitespace, simple and long strings (truncation), and type casting (stringifying numbers/booleans).
✨ **Result:** 100% coverage on `normalizeOperativeAvatarSeed` fallback resolution utility, protecting against regressions in seed-based avatar generation.

---
*PR created automatically by Jules for task [7849332536391233488](https://jules.google.com/task/7849332536391233488) started by @blueneekone*