### PR TITLE
🧪 test: add coverage for fallbackPlayerName in profile.js

### DIFF
--- a/src/lib/auth/__tests__/profile.test.ts
+++ b/src/lib/auth/__tests__/profile.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { fallbackPlayerName } from '../profile.js';
+
+describe('fallbackPlayerName', () => {
+	it('should return playerName from baseProfile if present', () => {
+		const profile = { playerName: 'John Player', name: 'John', player: 'Johnny' };
+		expect(fallbackPlayerName(profile, 'john@example.com')).toBe('John Player');
+	});
+
+	it('should return name from baseProfile if playerName is not present', () => {
+		const profile = { name: 'John Name', player: 'Johnny' };
+		expect(fallbackPlayerName(profile, 'john@example.com')).toBe('John Name');
+	});
+
+	it('should return player from baseProfile if playerName and name are not present', () => {
+		const profile = { player: 'John Player Field' };
+		expect(fallbackPlayerName(profile, 'john@example.com')).toBe('John Player Field');
+	});
+
+	it('should fall back to local part of email if no valid name fields are in baseProfile', () => {
+		const profile = { otherField: 'Something' };
+		expect(fallbackPlayerName(profile, 'jane.doe@example.com')).toBe('jane.doe');
+	});
+
+	it('should fall back to local part of email if baseProfile is null', () => {
+		expect(fallbackPlayerName(null, 'jane.doe@example.com')).toBe('jane.doe');
+	});
+
+	it('should fall back to local part of email if baseProfile is undefined', () => {
+		expect(fallbackPlayerName(undefined, 'jane.doe@example.com')).toBe('jane.doe');
+	});
+
+	it('should return "unknown" if baseProfile has no valid fields and email is undefined', () => {
+		expect(fallbackPlayerName(undefined, undefined)).toBe('unknown');
+	});
+
+	it('should return "unknown" if baseProfile has no valid fields and email is null', () => {
+		expect(fallbackPlayerName(null, null)).toBe('unknown');
+	});
+
+	it('should handle email with multiple @ symbols by splitting at the first one', () => {
+		expect(fallbackPlayerName(null, 'strange@email@example.com')).toBe('strange');
+	});
+
+	it('should return local part if baseProfile fields are empty strings', () => {
+		const profile = { playerName: '', name: '', player: '' };
+		expect(fallbackPlayerName(profile, 'localpart@example.com')).toBe('localpart');
+	});
+});


### PR DESCRIPTION
🎯 **What:** The testing gap in `fallbackPlayerName` (located in `src/lib/auth/profile.js`) has been fully addressed by implementing unit tests.
📊 **Coverage:** The new test file (`src/lib/auth/__tests__/profile.test.ts`) covers all paths:
- Extraction of `playerName`, `name`, or `player` based on precedence.
- Fallback to the local string portion of an email when fields are missing or empty.
- Null and undefined handling for profile configs and emails resulting in `'unknown'`.
- Validates string handling regarding multiple `@` symbols inside email strings.
✨ **Result:** Test coverage for `src/lib/auth/profile.js` is significantly improved, eliminating an untested fallback function that resolves naming conventions across the application context. No logic was altered, zeroing out regression risk.

---
*PR created automatically by Jules for task [923220943098734682](https://jules.google.com/task/923220943098734682) started by @blueneekone*