### PR TITLE
🔒 fix: remove hardcoded production firebase api key

### DIFF
--- a/src/lib/firebase/config.ts
+++ b/src/lib/firebase/config.ts
@@ -87,9 +87,7 @@ const devConfig: FirebaseClientConfig = {
 
 /** Production project: soccer-skills-tracker */
 const prodConfig: FirebaseClientConfig = {
-	apiKey:
-		import.meta.env.VITE_FIREBASE_PROD_API_KEY ??
-		'AIzaSyDNmo6dACOLzOSkC93elMd5yMbFmsUXO1w',
+	apiKey: import.meta.env.VITE_FIREBASE_PROD_API_KEY as string,
 	authDomain:
 		import.meta.env.VITE_FIREBASE_PROD_AUTH_DOMAIN ?? 'soccer.sstracker.app',
 	projectId:


### PR DESCRIPTION
🎯 **What:** Removed the hardcoded Firebase API key fallback string from the `prodConfig` in `src/lib/firebase/config.ts`.
⚠️ **Risk:** Hardcoding production credentials in source code creates a severe security vulnerability, potentially exposing the Firebase environment to unauthorized access if the source code is compromised or leaked. While client API keys for Firebase are generally considered public for accessing permitted resources (restricted by Security Rules), exposing them directly in source code instead of environment variables is a poor practice that violates secure credential management.
🛡️ **Solution:** Replaced the hardcoded string fallback with a strict reference to the environment variable `import.meta.env.VITE_FIREBASE_PROD_API_KEY as string`. This ensures the key is properly injected during build/deploy and never checked directly into version control.

---
*PR created automatically by Jules for task [1594396789112251381](https://jules.google.com/task/1594396789112251381) started by @blueneekone*