### PR TITLE
🧹 [code health improvement] Remove unused showLiveTelemetry prop in SquadMatrix.svelte

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -40,4 +40,5 @@
 - [x] **SSR COOKIE SYNC**: Resolved unauthenticated page loads by synchronizing IndexedDB token values to secure server cookies [cite: 50, 133, 134].
 - [x] **B815 HYDRATION GUARDS**: Standardized `if (!db || !authStore.isAuthenticated) return;` early checks on all dashboard queries to prevent loop quota blocks [cite: 345, 367].
 - [ ] **MARKETPLACE LAUNCH (Phase 4)**: Merge Svelte 5 Bento-grid view and deploy `bookTutoringSession` callable Stripe handler on `functions-commerce` [cite: 424].
+- [x] **CODE HEALTH**: Removed unused `showLiveTelemetry` prop from SquadMatrix component.
 - [x] **DIRECTOR OS & ADMIN OS OVERHAUL**: Admin active incidents click navigation and Director OS system-wide visual simplification.

--- a/src/lib/components/coach/SquadMatrix.svelte
+++ b/src/lib/components/coach/SquadMatrix.svelte
@@ -35,7 +35,7 @@
 		],
 	};
 
-	let { teamId = '', teams = [], showLiveTelemetry = true } = $props();
+	let { teamId = '', teams = [] } = $props();
 
 	/** Isolates one bench-side logging session (new UUID when `teamId` changes). */
 	let activeMatchId = $state('');


### PR DESCRIPTION
🎯 **What:** Removed the unused `showLiveTelemetry` prop from `SquadMatrix.svelte`.
💡 **Why:** ESLint flagged the prop as unused. Removing it cleans up the component's API signature, improving code readability and maintainability without altering functionality.
✅ **Verification:** Verified by running Svelte check (`npm run check`) to ensure no diagnostic errors and running the full test suite (`npm run test`) to confirm no regressions.
✨ **Result:** The `SquadMatrix` component no longer exposes the unused `showLiveTelemetry` prop, resolving the linter warning.

---
*PR created automatically by Jules for task [8829832746321649968](https://jules.google.com/task/8829832746321649968) started by @blueneekone*