### PR TITLE
🧹 [remove unused role variable]

### DIFF
--- a/src/lib/coach/drills/CoachDrillsView.svelte
+++ b/src/lib/coach/drills/CoachDrillsView.svelte
@@ -39,7 +39,6 @@
 		teamScope.syncSelectedTeam();
 	});
 
-	const role = $derived(teamScope.role);
 	const myTeams = $derived(teamScope.myTeams);
 	const currentTeam = $derived(teamScope.currentTeam);
 	const myEmail = $derived(authStore.user?.email ?? '');


### PR DESCRIPTION
🎯 **What:** Removed the unused `role` derived variable in `CoachDrillsView.svelte`.
💡 **Why:** ESLint flags 'role' as unused. Removing it resolves the lint warning and cleans up dead code without affecting functionality.
✅ **Verification:** Ran `pnpm run check` and verified Svelte diagnostics pass with 0 errors. Also ran `pnpm run test` to ensure no regressions were introduced.
✨ **Result:** A cleaner codebase with fewer lint warnings.

---
*PR created automatically by Jules for task [4733320109912691740](https://jules.google.com/task/4733320109912691740) started by @blueneekone*