### PR TITLE
🧹 [code health] Remove unused onSearchInput from GlobalUsersToolbar

### DIFF
--- a/src/lib/components/admin/GlobalUsersToolbar.svelte
+++ b/src/lib/components/admin/GlobalUsersToolbar.svelte
@@ -10,7 +10,6 @@
 		rangeStart: number;
 		rangeEnd: number;
 		totalLabel: string;
-		onSearchInput: (value: string) => void;
 		onSearchKey: (e: KeyboardEvent) => void;
 		onRunSearch: () => void;
 		onClearSearch: () => void;
@@ -24,7 +23,6 @@
 		rangeStart,
 		rangeEnd,
 		totalLabel,
-		onSearchInput,
 		onSearchKey,
 		onRunSearch,
 		onClearSearch,

--- a/src/routes/(app)/admin/users/AdminUsersHUD.svelte
+++ b/src/routes/(app)/admin/users/AdminUsersHUD.svelte
@@ -13,7 +13,6 @@
 	rangeStart={engine.rangeStart}
 	rangeEnd={engine.rangeEnd}
 	totalLabel={engine.totalLabel}
-	onSearchInput={(value) => (engine.searchInput = value)}
 	onSearchKey={engine.onSearchKey}
 	onRunSearch={() => void engine.runSearch()}
 	onClearSearch={() => void engine.clearSearch()}


### PR DESCRIPTION
🎯 **What:** Removed the unused `onSearchInput` prop from the `GlobalUsersToolbar` component and its corresponding usage in `AdminUsersHUD.svelte`.
💡 **Why:** This fixes an ESLint warning about an unused prop and cleans up the API surface of the component, improving code health and maintainability.
✅ **Verification:** Verified that the build passes and tests succeed locally using `pnpm run check` and `pnpm run test`.
✨ **Result:** A cleaner component API and removal of unused code, without changing the behavior of the application.

---
*PR created automatically by Jules for task [1767171090238466323](https://jules.google.com/task/1767171090238466323) started by @blueneekone*