### PR TITLE
🧹 [code health] Remove unused DISPATCH_INTEL constant in SquadMatrix

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -41,3 +41,4 @@
 - [x] **B815 HYDRATION GUARDS**: Standardized `if (!db || !authStore.isAuthenticated) return;` early checks on all dashboard queries to prevent loop quota blocks [cite: 345, 367].
 - [ ] **MARKETPLACE LAUNCH (Phase 4)**: Merge Svelte 5 Bento-grid view and deploy `bookTutoringSession` callable Stripe handler on `functions-commerce` [cite: 424].
 - [x] **DIRECTOR OS & ADMIN OS OVERHAUL**: Admin active incidents click navigation and Director OS system-wide visual simplification.
+- [x] **CODE HEALTH**: Removed unused `DISPATCH_INTEL` constant from SquadMatrix.

--- a/src/lib/components/coach/SquadMatrix.svelte
+++ b/src/lib/components/coach/SquadMatrix.svelte
@@ -26,15 +26,6 @@
 	import IntelModal from '$lib/components/ui/IntelModal.svelte';
 	import { buildCoachRosterDisplayNames } from '$lib/coach/rosterDisplayDedupe.js';
 
-	const DISPATCH_INTEL = {
-		title: 'DISPATCH PROTOCOL',
-		instructions: [
-			'1. Generate your 6-character code.',
-			'2. Text this code to your team parents.',
-			'3. Parents create an account, sign the COPPA waiver, and enter this code to instantly drop their player onto your roster.',
-		],
-	};
-
 	let { teamId = '', teams = [], showLiveTelemetry = true } = $props();
 
 	/** Isolates one bench-side logging session (new UUID when `teamId` changes). */


### PR DESCRIPTION
🎯 **What:** Removed the unused `DISPATCH_INTEL` constant from `src/lib/components/coach/SquadMatrix.svelte`.

💡 **Why:** ESLint flagged this static object definition as unused dead code. Removing it improves codebase maintainability and reduces clutter without altering behavior.

✅ **Verification:**
- Ran the test suite (`pnpm run test`) to verify no regressions were introduced. All tests passed.
- Ran Svelte diagnostics (`pnpm run check`) ensuring that the ESLint/svelte-check warnings regarding this specific constant are gone.
- Reviewed and updated `ROADMAP.md` to note the completion of this code health task.

✨ **Result:** A cleaner component with zero dead code and no ESLint warnings regarding unused variables in `SquadMatrix.svelte`.

---
*PR created automatically by Jules for task [1451684461502427286](https://jules.google.com/task/1451684461502427286) started by @blueneekone*