### PR TITLE
🧹 Remove unused variable in NewMessageEngine toggle

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -39,5 +39,6 @@
 - [x] **AUTH REMEDIATION**: Relocated user sign-in documents to lowercase `users/{email}` canonical format [cite: 130].
 - [x] **SSR COOKIE SYNC**: Resolved unauthenticated page loads by synchronizing IndexedDB token values to secure server cookies [cite: 50, 133, 134].
 - [x] **B815 HYDRATION GUARDS**: Standardized `if (!db || !authStore.isAuthenticated) return;` early checks on all dashboard queries to prevent loop quota blocks [cite: 345, 367].
+- [x] **CODE HEALTH**: Refactored `NewMessageEngine.svelte.ts` to remove unused variables and fix linting warnings.
 - [ ] **MARKETPLACE LAUNCH (Phase 4)**: Merge Svelte 5 Bento-grid view and deploy `bookTutoringSession` callable Stripe handler on `functions-commerce` [cite: 424].
 - [x] **DIRECTOR OS & ADMIN OS OVERHAUL**: Admin active incidents click navigation and Director OS system-wide visual simplification.

--- a/src/lib/components/coach/NewMessageEngine.svelte.ts
+++ b/src/lib/components/coach/NewMessageEngine.svelte.ts
@@ -142,7 +142,6 @@ export class NewMessageEngine {
 	}
 
 	toggle(email: string) {
-		const c = this.candidates.find((x) => x.email === email);
 		const next = new Set(this.selected);
 		const k = email.toLowerCase();
 		if (next.has(k)) next.delete(k);


### PR DESCRIPTION
🎯 **What:** Removed unused variable `c` in the `toggle` function inside `src/lib/components/coach/NewMessageEngine.svelte.ts`. Updated `ROADMAP.md` completion status.

💡 **Why:** ESLint highlighted `c` as an unused variable since it only performed an array find operation without its result being utilized. Removing it cleans up code and removes warnings, improving maintainability.

✅ **Verification:** Verified that linting passes cleanly via `pnpm run check` and executed `pnpm run test` to confirm there were no functionality regressions.

✨ **Result:** A cleaner implementation of the `toggle` function that passes all checks without throwing unused-variable warnings.

---
*PR created automatically by Jules for task [13173465687266147890](https://jules.google.com/task/13173465687266147890) started by @blueneekone*