### PR TITLE
🧹 [code health improvement] Remove unused myTeams derived state

### DIFF
--- a/src/lib/coach/match-day/CoachMatchDayView.svelte
+++ b/src/lib/coach/match-day/CoachMatchDayView.svelte
@@ -60,7 +60,6 @@
 	});
 
 	const role = $derived(teamScope.role);
-	const myTeams = $derived(teamScope.myTeams);
 
 	const activeTeamLabel = $derived.by(() => {
 		const n = typeof teamScope.currentTeam?.name === 'string' ? teamScope.currentTeam.name.trim() : '';


### PR DESCRIPTION
🎯 **What:** Removed the unused `myTeams` derived state from `CoachMatchDayView.svelte` flagged by ESLint.
💡 **Why:** To improve code health by reducing unnecessary reactivity computations and resolving the lint warning.
✅ **Verification:** Verified via `pnpm run check` and `pnpm run test`. Also ensured that I didn't unnecessarily broaden scope to break uncompleted adjacent variables (e.g. `role`).
✨ **Result:** Improved codebase cleanliness and adherence to lint rules without affecting runtime behavior.

---
*PR created automatically by Jules for task [7598695229703514017](https://jules.google.com/task/7598695229703514017) started by @blueneekone*