### PR TITLE
🧹 [code health] Fix unused onKey event handler in OrganizationSidecar

### DIFF
--- a/src/lib/components/admin/OrganizationSidecar.svelte
+++ b/src/lib/components/admin/OrganizationSidecar.svelte
@@ -92,6 +92,10 @@
 		const onKey = (e) => {
 			if (e.key === 'Escape' && !saving) onClose?.();
 		};
+		if (typeof window !== 'undefined') window.addEventListener('keydown', onKey);
+		return () => {
+			if (typeof window !== 'undefined') window.removeEventListener('keydown', onKey);
+		};
 	});
 
 	async function submit() {


### PR DESCRIPTION
🎯 **What:** Fixed the unused `onKey` event handler warning in `src/lib/components/admin/OrganizationSidecar.svelte` by properly attaching it as a `keydown` listener to the `window` object.
💡 **Why:** This improves code maintainability by resolving an ESLint warning and properly implements the intended accessibility feature (closing the modal via the Escape key).
✅ **Verification:** Verified by running `pnpm run check` and `pnpm run test` which both passed successfully without introducing any new warnings or errors. Code review confirmed the fix is correct, safe, and maintainable.
✨ **Result:** The `OrganizationSidecar` modal can now be properly closed using the Escape key, and the codebase is cleaner with the unused variable warning resolved.

---
*PR created automatically by Jules for task [5927809940564677824](https://jules.google.com/task/5927809940564677824) started by @blueneekone*