### PR TITLE
🧹 [code health improvement] Remove unused headerClass derived state in Card.svelte

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -41,3 +41,4 @@
 - [x] **B815 HYDRATION GUARDS**: Standardized `if (!db || !authStore.isAuthenticated) return;` early checks on all dashboard queries to prevent loop quota blocks [cite: 345, 367].
 - [ ] **MARKETPLACE LAUNCH (Phase 4)**: Merge Svelte 5 Bento-grid view and deploy `bookTutoringSession` callable Stripe handler on `functions-commerce` [cite: 424].
 - [x] **DIRECTOR OS & ADMIN OS OVERHAUL**: Admin active incidents click navigation and Director OS system-wide visual simplification.
+- [x] **CODE HEALTH**: Removed unused `headerClass` state variable from `Card.svelte` component.

--- a/src/lib/components/Card.svelte
+++ b/src/lib/components/Card.svelte
@@ -10,14 +10,6 @@
 		children,
 		headerSlot
 	} = $props();
-
-	const headerClass = $derived({
-		'bg-blue-header': headerVariant === 'blue',
-		'bg-gold-header': headerVariant === 'gold',
-		'bg-green-header': headerVariant === 'green',
-		'bg-red-header': headerVariant === 'red',
-		'bg-orange-header': headerVariant === 'orange'
-	});
 </script>
 
 <div


### PR DESCRIPTION
🎯 **What:** Removed the unused `headerClass` derived state variable from `src/lib/components/Card.svelte`.
💡 **Why:** This resolves an ESLint warning for an unused variable. The classes were already being applied directly to the `<div class="card-header">` element in the template, so the derived variable was completely redundant. Removing dead code improves code maintainability.
✅ **Verification:** Ran `npm run check` which returned 0 Svelte diagnostics errors. Ran `npx eslint src/lib/components/Card.svelte` with no output. Ran `vitest run` which showed all tests passing. The ROADMAP.md has been updated.
✨ **Result:** A cleaner component file without unused state and a resolved ESLint warning.

---
*PR created automatically by Jules for task [4880851382887321782](https://jules.google.com/task/4880851382887321782) started by @blueneekone*