### PR TITLE
🧹 [code health improvement] Remove unused players prop in MessagesTab

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -41,3 +41,4 @@
 - [x] **B815 HYDRATION GUARDS**: Standardized `if (!db || !authStore.isAuthenticated) return;` early checks on all dashboard queries to prevent loop quota blocks [cite: 345, 367].
 - [ ] **MARKETPLACE LAUNCH (Phase 4)**: Merge Svelte 5 Bento-grid view and deploy `bookTutoringSession` callable Stripe handler on `functions-commerce` [cite: 424].
 - [x] **DIRECTOR OS & ADMIN OS OVERHAUL**: Admin active incidents click navigation and Director OS system-wide visual simplification.
+- [x] **CODE HEALTH**: Removed unused _players prop from MessagesTab components.

--- a/src/lib/components/coach/MessagesTab.svelte
+++ b/src/lib/components/coach/MessagesTab.svelte
@@ -27,7 +27,7 @@
 		type MessagesTabChannel,
 	} from '$lib/coach/comms/messagesTabChannels.js';
 
-	let { teamId = '', players: _players = [], clubId = '', initialChannel = '' } = $props();
+	let { teamId = '', clubId = '', initialChannel = '' } = $props();
 
 	let newChannelOpen = $state(false);
 	let channelCreatedMsg = $state('');


### PR DESCRIPTION
🎯 **What:** Removed the unused `players` prop (aliased to `_players`) in `src/lib/components/coach/MessagesTab.svelte`.
💡 **Why:** To fix an ESLint warning about an unused variable and improve overall codebase health and cleanliness.
✅ **Verification:** Verified by running Svelte diagnostics (`pnpm run check`) which reported 0 errors, and by running the full Vitest suite (`pnpm run test`), where all 3839 tests passed correctly. 
✨ **Result:** A cleaner component signature without unused variables dangling in the prop destructurings.

---
*PR created automatically by Jules for task [3724017009713569472](https://jules.google.com/task/3724017009713569472) started by @blueneekone*