### PR TITLE
🔒 [Fix hardcoded Firebase API keys]

### DIFF
--- a/src/lib/firebase.js
+++ b/src/lib/firebase.js
@@ -48,7 +48,7 @@ import {
 
 /** Development project — sports-skill-tracker-dev */
 const devConfig = {
-	apiKey: import.meta.env.VITE_FIREBASE_DEV_API_KEY || 'AIzaSyCiBoemXJHTkTnujTwM1vOJc4FrVZF8Lw8',
+	apiKey: import.meta.env.VITE_FIREBASE_DEV_API_KEY,
 	authDomain:
 		import.meta.env.VITE_FIREBASE_DEV_AUTH_DOMAIN ||
 		'sports-skill-tracker-dev.firebaseapp.com',
@@ -64,7 +64,7 @@ const devConfig = {
 
 /** Production project — soccer-skills-tracker */
 const prodConfig = {
-	apiKey: import.meta.env.VITE_FIREBASE_PROD_API_KEY || 'AIzaSyDNmo6dACOLzOSkC93elMd5yMbFmsUXO1w',
+	apiKey: import.meta.env.VITE_FIREBASE_PROD_API_KEY,
 	authDomain:
 		import.meta.env.VITE_FIREBASE_PROD_AUTH_DOMAIN || 'soccer.sstracker.app',
 	projectId: import.meta.env.VITE_FIREBASE_PROD_PROJECT_ID || 'soccer-skills-tracker',

--- a/src/lib/firebase/config.ts
+++ b/src/lib/firebase/config.ts
@@ -65,9 +65,7 @@ interface FirebaseClientConfig {
 
 /** Development project: sports-skill-tracker-dev */
 const devConfig: FirebaseClientConfig = {
-	apiKey:
-		import.meta.env.VITE_FIREBASE_DEV_API_KEY ??
-		'AIzaSyCiBoemXJHTkTnujTwM1vOJc4FrVZF8Lw8',
+	apiKey: import.meta.env.VITE_FIREBASE_DEV_API_KEY as string,
 	authDomain:
 		import.meta.env.VITE_FIREBASE_DEV_AUTH_DOMAIN ??
 		'sports-skill-tracker-dev.firebaseapp.com',
@@ -87,9 +85,7 @@ const devConfig: FirebaseClientConfig = {
 
 /** Production project: soccer-skills-tracker */
 const prodConfig: FirebaseClientConfig = {
-	apiKey:
-		import.meta.env.VITE_FIREBASE_PROD_API_KEY ??
-		'AIzaSyDNmo6dACOLzOSkC93elMd5yMbFmsUXO1w',
+	apiKey: import.meta.env.VITE_FIREBASE_PROD_API_KEY as string,
 	authDomain:
 		import.meta.env.VITE_FIREBASE_PROD_AUTH_DOMAIN ?? 'soccer.sstracker.app',
 	projectId:


### PR DESCRIPTION
🎯 **What:** Removed hardcoded Firebase API keys (`AIzaSyCi...` and `AIzaSyDN...`) from `devConfig` and `prodConfig` inside `src/lib/firebase.js` and `src/lib/firebase/config.ts`.
⚠️ **Risk:** Including hardcoded fallback values for API keys within source code risks exposing potentially sensitive project connection details if the repository code is leaked, failing security audits regarding hardcoded credentials. 
🛡️ **Solution:** Modified the configuration definitions to rely strictly on Vite environment variables (`import.meta.env.VITE_FIREBASE_DEV_API_KEY`, etc.), using TypeScript type assertions where necessary instead of string fallbacks, ensuring secrets must be provided securely via standard environment injection.

---
*PR created automatically by Jules for task [7027337790333200443](https://jules.google.com/task/7027337790333200443) started by @blueneekone*