### PR TITLE
🔒 [security fix] Remove hardcoded Firebase API keys

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,2 @@
+VITE_FIREBASE_DEV_API_KEY=mock-dev-api-key
+VITE_FIREBASE_PROD_API_KEY=mock-prod-api-key

--- a/src/lib/firebase.js
+++ b/src/lib/firebase.js
@@ -48,7 +48,7 @@ import {
 
 /** Development project — sports-skill-tracker-dev */
 const devConfig = {
-	apiKey: import.meta.env.VITE_FIREBASE_DEV_API_KEY || 'AIzaSyCiBoemXJHTkTnujTwM1vOJc4FrVZF8Lw8',
+	apiKey: import.meta.env.VITE_FIREBASE_DEV_API_KEY,
 	authDomain:
 		import.meta.env.VITE_FIREBASE_DEV_AUTH_DOMAIN ||
 		'sports-skill-tracker-dev.firebaseapp.com',
@@ -64,7 +64,7 @@ const devConfig = {
 
 /** Production project — soccer-skills-tracker */
 const prodConfig = {
-	apiKey: import.meta.env.VITE_FIREBASE_PROD_API_KEY || 'AIzaSyDNmo6dACOLzOSkC93elMd5yMbFmsUXO1w',
+	apiKey: import.meta.env.VITE_FIREBASE_PROD_API_KEY,
 	authDomain:
 		import.meta.env.VITE_FIREBASE_PROD_AUTH_DOMAIN || 'soccer.sstracker.app',
 	projectId: import.meta.env.VITE_FIREBASE_PROD_PROJECT_ID || 'soccer-skills-tracker',


### PR DESCRIPTION
🎯 **What:** Removed hardcoded Firebase API keys (`VITE_FIREBASE_DEV_API_KEY` and `VITE_FIREBASE_PROD_API_KEY`) from `src/lib/firebase.js`.
⚠️ **Risk:** Hardcoding API keys is a bad practice. Even though Firebase web API keys are technically meant to be exposed to clients, embedding them in the source code as string fallbacks circumvents proper environment variable management and increases risk if the keys need rotation or differ significantly across environments.
🛡️ **Solution:** The fallbacks were stripped out, leaving only the `import.meta.env.*` variables. To ensure the local test suite continues to pass without the hardcoded keys, a `.env.test` file was added to mock these keys for Vitest.

---
*PR created automatically by Jules for task [13816303941791590068](https://jules.google.com/task/13816303941791590068) started by @blueneekone*