### PR TITLE
🧹 [Coach OS] Simplify Match Day HUD layout and normalize design tokens

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -42,3 +42,4 @@
 - [x] **SYSTEMIC BACKEND & REACTIVITY REPAIR**: RosterPanelEngine hydration logic and atomic claims sync via secure backend Cloud Functions.
 - [ ] **MARKETPLACE LAUNCH (Phase 4)**: Merge Svelte 5 Bento-grid view and deploy `bookTutoringSession` callable Stripe handler on `functions-commerce` [cite: 424].
 - [x] **DIRECTOR OS & ADMIN OS OVERHAUL**: Admin active incidents click navigation and Director OS system-wide visual simplification.
+- [x] **COACH OS OVERHAUL**: Simplified Match Day layout and normalized design system colors (Void Black, Navy Slate, Action Gold, Data Cyan).

--- a/patch_roadmap.sh
+++ b/patch_roadmap.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+awk '
+{
+  print $0
+  if ($0 ~ /- \[x\] \*\*DIRECTOR OS & ADMIN OS OVERHAUL\*\*: Admin active incidents click navigation and Director OS system-wide visual simplification./) {
+    print "- [x] **COACH OS OVERHAUL**: Simplified Match Day layout and normalized design system colors (Void Black, Navy Slate, Action Gold, Data Cyan)."
+  }
+}' ROADMAP.md > ROADMAP_temp.md && mv ROADMAP_temp.md ROADMAP.md

--- a/src/routes/(app)/coach/matchday/+page.svelte
+++ b/src/routes/(app)/coach/matchday/+page.svelte
@@ -11,8 +11,8 @@
 </svelte:head>
 
 <div
-	class="pd-matchday-root tw-min-h-screen tw-bg-[#0a0a0a] tw-text-white tw-p-6 tw-space-y-6"
-	style="background-color: rgb(10, 10, 10); border-radius: 0px;"
+	class="pd-matchday-root tw-min-h-screen tw-bg-[#000000] tw-text-white tw-p-6 tw-space-y-6"
+	style="background-color: rgb(0, 0, 0); border-radius: 0px;"
 >
 	<header class="tw-border-b tw-border-[#334155] tw-pb-4">
 		<h1 class="tw-font-mono tw-text-2xl tw-font-bold tw-text-[#fbbf24] tw-uppercase tw-tracking-tight">

--- a/src/routes/(app)/coach/matchday/MatchDayArena.svelte
+++ b/src/routes/(app)/coach/matchday/MatchDayArena.svelte
@@ -5,23 +5,23 @@
 </script>
 
 <div class="tw-flex tw-gap-2 tw-mb-4" style="border-radius: 0px;">
-	<button onclick={() => engine.activeTab = 'live'} class="tw-px-4 tw-py-2 tw-font-mono tw-text-xs tw-font-bold tw-transition-colors {engine.activeTab === 'live' ? 'tw-bg-[#06b6d4] tw-text-black' : 'tw-bg-[#1e293b] tw-text-gray-400 tw-border tw-border-[#334155] hover:tw-text-white'}">[ LIVE MATCH ]</button>
-	<button onclick={() => engine.activeTab = 'roster'} class="tw-px-4 tw-py-2 tw-font-mono tw-text-xs tw-font-bold tw-transition-colors {engine.activeTab === 'roster' ? 'tw-bg-[#06b6d4] tw-text-black' : 'tw-bg-[#1e293b] tw-text-gray-400 tw-border tw-border-[#334155] hover:tw-text-white'}">[ ROSTER & SUBS ]</button>
-	<button onclick={() => engine.activeTab = 'review'} class="tw-px-4 tw-py-2 tw-font-mono tw-text-xs tw-font-bold tw-transition-colors {engine.activeTab === 'review' ? 'tw-bg-[#06b6d4] tw-text-black' : 'tw-bg-[#1e293b] tw-text-gray-400 tw-border tw-border-[#334155] hover:tw-text-white'}">[ POST-MATCH REVIEW ]</button>
+	<button onclick={() => engine.activeTab = 'live'} class="tw-px-4 tw-py-2 tw-font-mono tw-text-xs tw-font-bold tw-transition-colors {engine.activeTab === 'live' ? 'tw-bg-[#14b8a6] tw-text-black' : 'tw-bg-[#0f172a] tw-text-gray-400 tw-border tw-border-[#334155] hover:tw-text-white'}">[ LIVE MATCH ]</button>
+	<button onclick={() => engine.activeTab = 'roster'} class="tw-px-4 tw-py-2 tw-font-mono tw-text-xs tw-font-bold tw-transition-colors {engine.activeTab === 'roster' ? 'tw-bg-[#14b8a6] tw-text-black' : 'tw-bg-[#0f172a] tw-text-gray-400 tw-border tw-border-[#334155] hover:tw-text-white'}">[ ROSTER & SUBS ]</button>
+	<button onclick={() => engine.activeTab = 'review'} class="tw-px-4 tw-py-2 tw-font-mono tw-text-xs tw-font-bold tw-transition-colors {engine.activeTab === 'review' ? 'tw-bg-[#14b8a6] tw-text-black' : 'tw-bg-[#0f172a] tw-text-gray-400 tw-border tw-border-[#334155] hover:tw-text-white'}">[ POST-MATCH REVIEW ]</button>
 </div>
 
 <div class="tw-grid tw-grid-cols-12 tw-gap-4" style="border-radius: 0px;">
 	{#if engine.activeTab === 'live'}
 	<!-- 12-Column Asymmetric Grid: Game Event Loggers -->
-	<div class="tw-col-span-12 md:tw-col-span-8 tw-bg-[#1e293b] tw-border tw-border-[#334155] tw-p-4" style="border-radius: 0px;">
-		<div class="tw-font-mono tw-text-xs tw-text-[#06b6d4] tw-uppercase tw-tracking-wider tw-mb-3">
+	<div class="tw-col-span-12 md:tw-col-span-8 tw-bg-[#0f172a] tw-border tw-border-[#334155] tw-p-4" style="border-radius: 0px;">
+		<div class="tw-font-mono tw-text-xs tw-text-[#14b8a6] tw-uppercase tw-tracking-wider tw-mb-3">
 			Live Match Loggers (Sub-14ms Latency)
 		</div>
 
 
 		<div class="tw-mb-4">
 			<label class="tw-block tw-font-mono tw-text-xs tw-text-gray-400 tw-mb-1">Target Player</label>
-			<select bind:value={engine.selectedPlayerId} class="tw-w-full tw-bg-[#0a0a0a] tw-border tw-border-[#334155] tw-text-white tw-px-3 tw-py-2 tw-font-mono tw-text-sm" style="border-radius: 0px;">
+			<select bind:value={engine.selectedPlayerId} class="tw-w-full tw-bg-[#000000] tw-border tw-border-[#334155] tw-text-white tw-px-3 tw-py-2 tw-font-mono tw-text-sm" style="border-radius: 0px;">
 				<option value="">-- Select Player --</option>
 				{#each engine.roster as player}
 					<option value={player.id}>{player.name}</option>
@@ -57,7 +57,7 @@
 			<button
 				type="button"
 				onclick={() => engine.logEvent('SUB', 'PLAYER SUB LOGGED')}
-				class="tw-bg-[#06b6d4] tw-text-black tw-font-mono tw-font-bold tw-px-4 tw-py-2 tw-text-sm hover:tw-opacity-90"
+				class="tw-bg-[#14b8a6] tw-text-black tw-font-mono tw-font-bold tw-px-4 tw-py-2 tw-text-sm hover:tw-opacity-90"
 				style="border-radius: 0px;"
 			>
 				+ SUB
@@ -79,10 +79,10 @@
 			{:else}
 				{#each engine.events as evt (evt.id)}
 					<div
-						class="match-event-row tw-bg-[#0a0a0a] tw-border tw-border-[#334155] tw-p-2 tw-flex tw-justify-between tw-items-center"
+						class="match-event-row tw-bg-[#000000] tw-border tw-border-[#334155] tw-p-2 tw-flex tw-justify-between tw-items-center"
 						style="border-radius: 0px;"
 					>
-						<span class="tw-font-mono tw-text-xs tw-text-[#06b6d4] tw-font-bold">{evt.label}</span>
+						<span class="tw-font-mono tw-text-xs tw-text-[#14b8a6] tw-font-bold">{evt.label}</span>
 						<span class="tw-font-mono tw-text-[11px] tw-text-gray-400">{evt.time}</span>
 					</div>
 				{/each}
@@ -91,7 +91,7 @@
 	</div>
 
 	<!-- Sidebar Control Deck: Halftime Planner -->
-	<div class="tw-col-span-12 md:tw-col-span-4 tw-bg-[#1e293b] tw-border tw-border-[#334155] tw-p-4" style="border-radius: 0px;">
+	<div class="tw-col-span-12 md:tw-col-span-4 tw-bg-[#0f172a] tw-border tw-border-[#334155] tw-p-4" style="border-radius: 0px;">
 		<div class="tw-font-mono tw-text-xs tw-text-[#fbbf24] tw-uppercase tw-tracking-wider tw-mb-3">
 			Halftime Tactical Control
 		</div>
@@ -99,7 +99,7 @@
 		<button
 			type="button"
 			onclick={() => engine.syncHalftimeChoice()}
-			class="tw-w-full tw-bg-[#0a0a0a] tw-text-[#fbbf24] tw-border tw-border-[#fbbf24] tw-px-4 tw-py-2.5 tw-font-mono tw-text-xs tw-font-bold hover:tw-bg-[#fbbf24] hover:tw-text-black tw-transition-colors"
+			class="tw-w-full tw-bg-[#000000] tw-text-[#fbbf24] tw-border tw-border-[#fbbf24] tw-px-4 tw-py-2.5 tw-font-mono tw-text-xs tw-font-bold hover:tw-bg-[#fbbf24] hover:tw-text-black tw-transition-colors"
 			style="border-radius: 0px;"
 		>
 			SYNC HALFTIME CHOICE
@@ -107,7 +107,7 @@
 
 		{#if engine.showHalftimeOverlay}
 			<div
-				class="halftime-choice-overlay tw-mt-4 tw-bg-[#0a0a0a] tw-border tw-border-[#fbbf24] tw-p-3"
+				class="halftime-choice-overlay tw-mt-4 tw-bg-[#000000] tw-border tw-border-[#fbbf24] tw-p-3"
 				style="border-radius: 0px;"
 			>
 				<div class="tw-font-mono tw-text-xs tw-text-[#fbbf24] tw-font-bold tw-uppercase">
@@ -122,20 +122,20 @@
 	{/if}
 
 	{#if engine.activeTab === 'roster'}
-	<div class="tw-col-span-12 tw-bg-[#1e293b] tw-border tw-border-[#334155] tw-p-4" style="border-radius: 0px;">
+	<div class="tw-col-span-12 tw-bg-[#0f172a] tw-border tw-border-[#334155] tw-p-4" style="border-radius: 0px;">
 		<div class="tw-font-mono tw-text-xs tw-text-[#fbbf24] tw-uppercase tw-tracking-wider tw-mb-3">
 			Starting Lineup vs Bench
 		</div>
 		<div class="tw-grid tw-grid-cols-2 tw-gap-6">
 			<div>
 				<h3 class="tw-font-mono tw-text-sm tw-text-gray-300 tw-mb-2">Starting Lineup</h3>
-				<div class="tw-space-y-2 tw-p-4 tw-bg-[#0a0a0a] tw-border tw-border-[#334155] tw-min-h-[200px]">
+				<div class="tw-space-y-2 tw-p-4 tw-bg-[#000000] tw-border tw-border-[#334155] tw-min-h-[200px]">
 					<div class="tw-text-xs tw-text-gray-500 tw-font-mono">Drag players here...</div>
 				</div>
 			</div>
 			<div>
 				<h3 class="tw-font-mono tw-text-sm tw-text-gray-300 tw-mb-2">Bench</h3>
-				<div class="tw-space-y-2 tw-p-4 tw-bg-[#0a0a0a] tw-border tw-border-[#334155] tw-min-h-[200px]">
+				<div class="tw-space-y-2 tw-p-4 tw-bg-[#000000] tw-border tw-border-[#334155] tw-min-h-[200px]">
 					<div class="tw-text-xs tw-text-gray-500 tw-font-mono">Drag players here...</div>
 				</div>
 			</div>
@@ -144,7 +144,7 @@
 	{/if}
 
 	{#if engine.activeTab === 'review'}
-	<div class="tw-col-span-12 tw-bg-[#1e293b] tw-border tw-border-[#334155] tw-p-4" style="border-radius: 0px;">
+	<div class="tw-col-span-12 tw-bg-[#0f172a] tw-border tw-border-[#334155] tw-p-4" style="border-radius: 0px;">
 		<div class="tw-font-mono tw-text-xs tw-text-[#fbbf24] tw-uppercase tw-tracking-wider tw-mb-3">
 			Post-Match Data Table
 		</div>
@@ -159,11 +159,11 @@
 				</thead>
 				<tbody>
 					{#each engine.events as evt (evt.id)}
-					<tr class="tw-border-b tw-border-[#334155]/50 hover:tw-bg-[#0a0a0a]">
+					<tr class="tw-border-b tw-border-[#334155]/50 hover:tw-bg-[#000000]">
 						<td class="tw-p-2 tw-font-mono tw-text-[11px] tw-text-gray-300">{evt.time}</td>
-						<td class="tw-p-2 tw-font-mono tw-text-xs tw-text-[#06b6d4]">{evt.type}</td>
+						<td class="tw-p-2 tw-font-mono tw-text-xs tw-text-[#14b8a6]">{evt.type}</td>
 						<td class="tw-p-2">
-							<input type="text" value={evt.label} onchange={(e) => engine.editEvent(evt.id, e.currentTarget.value)} class="tw-bg-transparent tw-border-none tw-text-white tw-font-mono tw-text-xs tw-w-full focus:tw-ring-1 focus:tw-ring-[#06b6d4] tw-px-1" />
+							<input type="text" value={evt.label} onchange={(e) => engine.editEvent(evt.id, e.currentTarget.value)} class="tw-bg-transparent tw-border-none tw-text-white tw-font-mono tw-text-xs tw-w-full focus:tw-ring-1 focus:tw-ring-[#14b8a6] tw-px-1" />
 						</td>
 					</tr>
 					{/each}

--- a/src/routes/(app)/coach/matchday/MatchDayHUD.svelte
+++ b/src/routes/(app)/coach/matchday/MatchDayHUD.svelte
@@ -29,7 +29,7 @@
 	});
 </script>
 
-<div class="tw-bg-[#1e293b] tw-border tw-border-[#334155] tw-p-4 tw-rounded-none" style="border-radius: 0px;">
+<div class="tw-bg-[#0f172a] tw-border tw-border-[#334155] tw-p-4 tw-rounded-none" style="border-radius: 0px;">
 	{#if engine.lightningDistance <= 10}
 		<div
 			class="tw-w-full tw-p-3 tw-mb-4 tw-font-mono tw-text-sm tw-font-bold tw-text-black tw-uppercase tw-text-center {engine.lightningDistance < 6 ? 'tw-bg-[#dc2626] tw-animate-pulse' : 'tw-bg-[#f59e0b]'}"
@@ -45,13 +45,13 @@
 	{/if}
 
 	<!-- Game Clock & Match Controls Strap -->
-	<div class="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-4 tw-mb-4 tw-p-3 tw-bg-[#0a0a0a] tw-border tw-border-[#334155]">
+	<div class="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-4 tw-mb-4 tw-p-3 tw-bg-[#000000] tw-border tw-border-[#334155]">
 		<div class="tw-flex tw-items-center tw-gap-4">
 			<div>
 				<div class="tw-font-mono tw-text-[10px] tw-text-slate-400 tw-uppercase tw-tracking-widest">GAME CLOCK</div>
-				<div class="tw-font-mono tw-text-2xl tw-font-black tw-text-[#daff0a] tw-tabular-nums">{matchClockDisplay}</div>
+				<div class="tw-font-mono tw-text-2xl tw-font-black tw-text-[#fbbf24] tw-tabular-nums">{matchClockDisplay}</div>
 			</div>
-			<span class="tw-text-[10px] tw-font-mono tw-px-2 tw-py-0.5 tw-border {engine.matchStatus === 'running' ? 'tw-bg-emerald-950/60 tw-border-emerald-500/60 tw-text-emerald-400 tw-animate-pulse' : engine.matchStatus === 'paused' ? 'tw-bg-amber-950/60 tw-border-amber-500/60 tw-text-amber-400' : engine.matchStatus === 'ended' ? 'tw-bg-slate-900 tw-border-slate-700 tw-text-slate-400' : 'tw-bg-slate-900 tw-border-slate-700 tw-text-[#daff0a]'}">
+			<span class="tw-text-[10px] tw-font-mono tw-px-2 tw-py-0.5 tw-border {engine.matchStatus === 'running' ? 'tw-bg-emerald-950/60 tw-border-emerald-500/60 tw-text-emerald-400 tw-animate-pulse' : engine.matchStatus === 'paused' ? 'tw-bg-amber-950/60 tw-border-amber-500/60 tw-text-amber-400' : engine.matchStatus === 'ended' ? 'tw-bg-slate-900 tw-border-slate-700 tw-text-slate-400' : 'tw-bg-slate-900 tw-border-slate-700 tw-text-[#fbbf24]'}">
 				{engine.matchStatus === 'running' ? '● LIVE' : engine.matchStatus === 'paused' ? '⏸ PAUSED' : engine.matchStatus === 'ended' ? '✓ FINAL' : 'PRE-MATCH'}
 			</span>
 		</div>
@@ -61,7 +61,7 @@
 				<button
 					type="button"
 					onclick={() => engine.startMatch()}
-					class="tw-bg-[#daff0a] tw-text-black tw-font-mono tw-font-black tw-text-xs tw-px-4 tw-py-2 tw-uppercase hover:tw-bg-lime-400 tw-transition-all"
+					class="tw-bg-[#fbbf24] tw-text-black tw-font-mono tw-font-black tw-text-xs tw-px-4 tw-py-2 tw-uppercase hover:tw-bg-lime-400 tw-transition-all"
 				>
 					▶ START MATCH
 				</button>
@@ -108,23 +108,6 @@
 	</div>
 
 
-	<div class="tw-flex tw-gap-4 tw-mb-4 tw-p-3 tw-bg-[#0a0a0a] tw-border tw-border-[#334155]">
-		<div class="tw-flex-1">
-			<label class="tw-block tw-font-mono tw-text-[10px] tw-text-slate-400 tw-uppercase tw-mb-1">Opposing Team Name</label>
-			<input type="text" bind:value={engine.opponentName} class="tw-w-full tw-bg-[#1e293b] tw-border tw-border-[#334155] tw-text-white tw-px-3 tw-py-2 tw-font-mono tw-text-sm" placeholder="Enter opponent..." />
-		</div>
-		<div class="tw-w-32">
-			<label class="tw-block tw-font-mono tw-text-[10px] tw-text-slate-400 tw-uppercase tw-mb-1">Final Score</label>
-			<input type="text" bind:value={engine.finalScore} class="tw-w-full tw-bg-[#1e293b] tw-border tw-border-[#334155] tw-text-white tw-px-3 tw-py-2 tw-font-mono tw-text-sm" placeholder="e.g. 2-1" />
-		</div>
-		<div class="tw-flex-1">
-			<label class="tw-block tw-font-mono tw-text-[10px] tw-text-slate-400 tw-uppercase tw-mb-1">Match Start Time</label>
-			<div class="tw-w-full tw-bg-[#1e293b] tw-border tw-border-[#334155] tw-text-gray-300 tw-px-3 tw-py-2 tw-font-mono tw-text-sm tw-h-9 tw-flex tw-items-center">
-				{engine.matchStartTime ? new Date(engine.matchStartTime).toLocaleString() : 'Not started'}
-			</div>
-		</div>
-	</div>
-
 	<!-- Active Status Bar -->
 	<div class="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-4 tw-mb-4 tw-border-b tw-border-[#334155] tw-pb-3">
 		<div class="tw-flex tw-items-center tw-gap-3">
@@ -148,7 +131,7 @@
 				type="button"
 				aria-label="Toggle Car Ride Home Shield"
 				onclick={() => engine.toggleShield()}
-				class="tw-bg-[#0a0a0a] tw-text-[#fbbf24] tw-border tw-border-[#fbbf24] tw-px-3 tw-py-1.5 tw-font-mono tw-text-xs tw-font-bold hover:tw-bg-[#fbbf24] hover:tw-text-black tw-transition-colors"
+				class="tw-bg-[#000000] tw-text-[#fbbf24] tw-border tw-border-[#fbbf24] tw-px-3 tw-py-1.5 tw-font-mono tw-text-xs tw-font-bold hover:tw-bg-[#fbbf24] hover:tw-text-black tw-transition-colors"
 				style="border-radius: 0px;"
 			>
 				TOGGLE SHIELD
@@ -157,7 +140,7 @@
 				type="button"
 				aria-label="Toggle Game Whistle"
 				onclick={() => engine.toggleWhistle()}
-				class="tw-bg-[#0a0a0a] tw-text-[#06b6d4] tw-border tw-border-[#06b6d4] tw-px-3 tw-py-1.5 tw-font-mono tw-text-xs tw-font-bold hover:tw-bg-[#06b6d4] hover:tw-text-black tw-transition-colors"
+				class="tw-bg-[#000000] tw-text-[#14b8a6] tw-border tw-border-[#14b8a6] tw-px-3 tw-py-1.5 tw-font-mono tw-text-xs tw-font-bold hover:tw-bg-[#14b8a6] hover:tw-text-black tw-transition-colors"
 				style="border-radius: 0px;"
 			>
 				{engine.isWhistleActive ? 'GAME WHISTLE: ACTIVE' : 'GAME WHISTLE: INACTIVE'}
@@ -166,32 +149,18 @@
 			<button
 				type="button"
 				onclick={() => engine.isHelpDrawerOpen = true}
-				class="tw-bg-[#0a0a0a] tw-text-gray-400 tw-border tw-border-[#334155] tw-px-3 tw-py-1.5 tw-font-mono tw-text-xs tw-font-bold hover:tw-text-white tw-transition-colors"
+				class="tw-bg-[#000000] tw-text-gray-400 tw-border tw-border-[#334155] tw-px-3 tw-py-1.5 tw-font-mono tw-text-xs tw-font-bold hover:tw-text-white tw-transition-colors"
 				style="border-radius: 0px;"
 			>
-				[ ? HELP ]
+				[ ? SETTINGS ]
 			</button>
-		</div>
-	</div>
-
-	<!-- Diagnostic Telemetry Stream -->
-	<div class="tw-mb-4 tw-p-2 tw-bg-[#0a0a0a] tw-border tw-border-[#334155]" style="border-radius: 0px;">
-		<div class="tw-font-mono tw-text-[10px] tw-text-[#06b6d4] tw-uppercase tw-tracking-widest tw-mb-1">Telemetry Stream</div>
-		{#each engine.telemetryLogs.slice(0, 3) as log}
-			<div class="tw-font-mono tw-text-xs tw-text-gray-300">{log}</div>
-		{/each}
-
-		<div class="tw-mt-2 tw-flex tw-gap-2 tw-opacity-20 hover:tw-opacity-100 tw-transition-opacity">
-			<button class="tw-text-[10px] tw-bg-gray-800 tw-px-2 tw-py-1" onclick={() => engine.simulateLightning(8.5)}>Sim 8.5m</button>
-			<button class="tw-text-[10px] tw-bg-gray-800 tw-px-2 tw-py-1" onclick={() => engine.simulateLightning(5.2)}>Sim 5.2m</button>
-			<button class="tw-text-[10px] tw-bg-gray-800 tw-px-2 tw-py-1" onclick={() => engine.simulateLightning(20)}>Sim Clear</button>
 		</div>
 	</div>
 
 	<!-- TARGET Coaching Prompt Engine -->
 	{#key engine.targetPrompts}
 		<div
-			class="target-prompt-container tw-bg-[#0a0a0a] tw-border tw-border-[#334155] tw-p-4 tw-transition-all tw-duration-300"
+			class="target-prompt-container tw-bg-[#000000] tw-border tw-border-[#334155] tw-p-4 tw-transition-all tw-duration-300"
 			style="font-family: Switzer, sans-serif; border-radius: 0px;"
 		>
 			<div class="tw-font-mono tw-text-xs tw-text-[#fbbf24] tw-font-bold tw-uppercase tw-tracking-wider tw-mb-2">
@@ -200,7 +169,7 @@
 			<ul class="tw-space-y-1.5 tw-text-sm tw-text-gray-200">
 				{#each engine.targetPrompts as prompt}
 					<li class="tw-flex tw-items-start tw-gap-2">
-						<span class="tw-text-[#06b6d4] tw-font-bold">›</span>
+						<span class="tw-text-[#14b8a6] tw-font-bold">›</span>
 						<span class="{prompt.startsWith('RESET') || prompt.startsWith('PARK IT') ? 'tw-text-[#fbbf24] tw-font-bold' : ''}">{prompt}</span>
 					</li>
 				{/each}
@@ -212,20 +181,50 @@
 
 	<!-- Slide-Out Help Drawer (Z4) -->
 	{#if engine.isHelpDrawerOpen}
-		<div class="tw-fixed tw-inset-y-0 tw-right-0 tw-w-80 tw-bg-[#0a0a0a] tw-border-l tw-border-[#334155] tw-z-50 tw-p-6 tw-transform tw-transition-transform">
+		<div class="tw-fixed tw-inset-y-0 tw-right-0 tw-w-80 tw-bg-[#000000] tw-border-l tw-border-[#334155] tw-z-50 tw-p-6 tw-transform tw-transition-transform">
 			<div class="tw-flex tw-justify-between tw-items-center tw-mb-6">
-				<h2 class="tw-font-mono tw-text-lg tw-text-[#fbbf24] tw-font-bold">Match Day Help</h2>
+				<h2 class="tw-font-mono tw-text-lg tw-text-[#fbbf24] tw-font-bold">Match Day Settings</h2>
 				<button onclick={() => engine.isHelpDrawerOpen = false} class="tw-text-gray-400 hover:tw-text-white tw-font-mono">✕ CLOSE</button>
 			</div>
 
 			<div class="tw-space-y-6">
+				<div class="tw-flex tw-flex-col tw-gap-4">
+					<div>
+						<label class="tw-block tw-font-mono tw-text-[10px] tw-text-slate-400 tw-uppercase tw-mb-1">Opposing Team Name</label>
+						<input type="text" bind:value={engine.opponentName} class="tw-w-full tw-bg-[#0f172a] tw-border tw-border-[#334155] tw-text-white tw-px-3 tw-py-2 tw-font-mono tw-text-sm" placeholder="Enter opponent..." />
+					</div>
+					<div>
+						<label class="tw-block tw-font-mono tw-text-[10px] tw-text-slate-400 tw-uppercase tw-mb-1">Final Score</label>
+						<input type="text" bind:value={engine.finalScore} class="tw-w-full tw-bg-[#0f172a] tw-border tw-border-[#334155] tw-text-white tw-px-3 tw-py-2 tw-font-mono tw-text-sm" placeholder="e.g. 2-1" />
+					</div>
+					<div>
+						<label class="tw-block tw-font-mono tw-text-[10px] tw-text-slate-400 tw-uppercase tw-mb-1">Match Start Time</label>
+						<div class="tw-w-full tw-bg-[#0f172a] tw-border tw-border-[#334155] tw-text-gray-300 tw-px-3 tw-py-2 tw-font-mono tw-text-sm tw-h-9 tw-flex tw-items-center">
+							{engine.matchStartTime ? new Date(engine.matchStartTime).toLocaleString() : 'Not started'}
+						</div>
+					</div>
+				</div>
+
+				<div class="tw-p-2 tw-bg-[#000000] tw-border tw-border-[#334155]" style="border-radius: 0px;">
+					<div class="tw-font-mono tw-text-[10px] tw-text-[#14b8a6] tw-uppercase tw-tracking-widest tw-mb-1">Telemetry Stream</div>
+					{#each engine.telemetryLogs.slice(0, 3) as log}
+						<div class="tw-font-mono tw-text-xs tw-text-gray-300">{log}</div>
+					{/each}
+
+					<div class="tw-mt-2 tw-flex tw-gap-2 tw-opacity-20 hover:tw-opacity-100 tw-transition-opacity">
+						<button class="tw-text-[10px] tw-bg-gray-800 tw-px-2 tw-py-1" onclick={() => engine.simulateLightning(8.5)}>Sim 8.5m</button>
+						<button class="tw-text-[10px] tw-bg-gray-800 tw-px-2 tw-py-1" onclick={() => engine.simulateLightning(5.2)}>Sim 5.2m</button>
+						<button class="tw-text-[10px] tw-bg-gray-800 tw-px-2 tw-py-1" onclick={() => engine.simulateLightning(20)}>Sim Clear</button>
+					</div>
+				</div>
+
 				<div>
-					<h3 class="tw-font-mono tw-text-sm tw-text-[#06b6d4] tw-mb-2">Game Whistle</h3>
+					<h3 class="tw-font-mono tw-text-sm tw-text-[#14b8a6] tw-mb-2">Game Whistle</h3>
 					<p class="tw-text-sm tw-text-gray-300">Controls the active state of the match recording. Must be active to log events.</p>
 				</div>
 
 				<div>
-					<h3 class="tw-font-mono tw-text-sm tw-text-[#06b6d4] tw-mb-2">Toggle Shield</h3>
+					<h3 class="tw-font-mono tw-text-sm tw-text-[#14b8a6] tw-mb-2">Toggle Shield</h3>
 					<p class="tw-text-sm tw-text-gray-300">Activates the "Car Ride Home" shield. This initiates a 15-minute post-game data lockout for parents and players to prevent immediate analysis in the car.</p>
 				</div>
 			</div>

--- a/src/routes/(app)/compliance/+page.svelte
+++ b/src/routes/(app)/compliance/+page.svelte
@@ -68,7 +68,7 @@
 	<title>Background Screening — SSTracker</title>
 </svelte:head>
 
-<div class="coach-clearance-page">
+<div class="coach-clearance-page tw-p-8">
 	<div class="coach-clearance-page__inner">
 		<header class="coach-clearance-z4-chrome">
 			<div class="coach-clearance-z4-chrome__icon" aria-hidden="true">


### PR DESCRIPTION
🧹 [Coach OS] Simplify Match Day HUD layout and normalize design tokens

🎯 What
- Moved secondary match controls (Opposing Team, Final Score, Match Start Time) and diagnostic telemetry output into a slide-out drawer (renamed "Match Day Settings").
- Applied platform-standard 'Nuclear Americana Tech Noir' color tokens (Void Black, Navy Slate, Action Gold, Data Cyan) replacing unstandardized gray, lime, and cyan hues across MatchDay HUD and Arena components.
- Added standard padding (tw-p-8) to the `coach-clearance-page` container so the background screening content no longer hugs the left navigation drawer.

💡 Why
- Match Day HUD was visibly cluttered and used off-brand legacy colors (e.g., `#daff0a` radioactive yellow). Refactoring secondary forms to the drawer significantly simplifies the sideline viewport.
- The `compliance` background screening page was missing structural padding after layout migrations.

✅ Verification
- Validated UI components render correctly and match design specifications. 
- Passed Svelte compiler checks and all active E2E and functional tests.
- Captured Playwright screenshots to confirm layout and padding fixes.

✨ Result
Match Day now fits strictly within Coach OS SIEM constraints, offering a focused HUD, and the screening portal renders with correct bounding margins.

---
*PR created automatically by Jules for task [16678342200941902705](https://jules.google.com/task/16678342200941902705) started by @blueneekone*