### PR TITLE
🧹 fix(coach): resolve dashboard team visibility and local tab layout

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -42,3 +42,4 @@
 - [x] **SYSTEMIC BACKEND & REACTIVITY REPAIR**: RosterPanelEngine hydration logic and atomic claims sync via secure backend Cloud Functions.
 - [ ] **MARKETPLACE LAUNCH (Phase 4)**: Merge Svelte 5 Bento-grid view and deploy `bookTutoringSession` callable Stripe handler on `functions-commerce` [cite: 424].
 - [x] **DIRECTOR OS & ADMIN OS OVERHAUL**: Admin active incidents click navigation and Director OS system-wide visual simplification.
+- [x] **COACH OS DASHBOARD FIX**: Resolve coach team visibility and Mission Control tab configurations.

--- a/src/lib/coach/context/coachTeamScope.svelte.ts
+++ b/src/lib/coach/context/coachTeamScope.svelte.ts
@@ -38,6 +38,7 @@ export class CoachTeamScope {
 
 	role = $derived(authStore.role);
 	myEmail = $derived((authStore.user?.email || '').toLowerCase());
+	myUid = $derived(authStore.user?.uid || '');
 
 	myTeams = $derived.by((): CoachTeamRow[] => {
 		if (!teamsStore.loaded) return [];
@@ -50,8 +51,8 @@ export class CoachTeamScope {
 		) {
 			return teamsStore.teams.slice() as CoachTeamRow[];
 		}
-		if (!this.myEmail) return [];
-		return teamsStore.getCoachTeams(this.myEmail) as CoachTeamRow[];
+		if (!this.myEmail && !this.myUid) return [];
+		return teamsStore.getCoachTeams(this.myEmail, this.myUid) as CoachTeamRow[];
 	});
 
 	currentTeam = $derived(

--- a/src/lib/stores/teams.svelte.js
+++ b/src/lib/stores/teams.svelte.js
@@ -43,7 +43,7 @@ function createTeamsStore() {
 		const { auth } = await import('$lib/firebase.js');
 		const uid = auth?.currentUser?.uid;
 		if (uid) {
-			const snapUid = await getDocs(query(collection(db, 'teams'), where('coachUid', '==', uid))).catch(e => { console.error('Error fetching teams by coachUid', e); return null; });
+			const snapUid = await getDocs(query(collection(db, 'teams'), where('coachId', '==', uid))).catch(e => { console.error('Error fetching teams by coachId', e); return null; });
 			if (snapUid) snapUid.forEach(d => teamsArr.push({ id: d.id, ...d.data() }));
 		}
 
@@ -219,18 +219,19 @@ function createTeamsStore() {
 		},
 
 		/** Filter teams that a coach email manages (head or assistant) */
-		getCoachTeams(email) {
-			if (!email) return teams.slice();
-			const emLower = email.toLowerCase().trim();
+		getCoachTeams(email, uid) {
+			if (!email && !uid) return teams.slice();
+			const emLower = email ? email.toLowerCase().trim() : '';
 			const matched = teams.filter((t) => {
-				const isHeadString = (t.coachEmail || '').toLowerCase().trim() === emLower;
-				const isHeadArray = (t.coachEmails || []).some(
+				const isHeadString = emLower ? (t.coachEmail || '').toLowerCase().trim() === emLower : false;
+				const isHeadUid = uid ? t.coachId === uid : false;
+				const isHeadArray = emLower ? (t.coachEmails || []).some(
 					(e) => (e || '').toLowerCase().trim() === emLower,
-				);
-				const isAsst = (t.assistants || []).some(
+				) : false;
+				const isAsst = emLower ? (t.assistants || []).some(
 					(a) => (a || '').toLowerCase().trim() === emLower,
-				);
-				return isHeadString || isHeadArray || isAsst;
+				) : false;
+				return isHeadString || isHeadUid || isHeadArray || isAsst;
 			});
 			// If teams were loaded in coach scope, all loaded teams belong to this coach
 			return matched.length > 0 ? matched : teams.slice();

--- a/src/routes/(app)/coach/dashboard/DashboardArena.svelte
+++ b/src/routes/(app)/coach/dashboard/DashboardArena.svelte
@@ -9,11 +9,15 @@
 </script>
 
 <div class="coach-mainboard-grid tw-grid-cols-12 tw-gap-4 st-bento" style="display: grid;" aria-label="Nexus Command workspace">
-	<!-- Top Navigation Section (2-section grid) -->
-	<div class="tw-col-span-12 tw-grid tw-grid-cols-2 tw-gap-4 tw-mb-2">
-		<a href="/coach/dashboard" class="vanguard-panel dashboard-card tw-flex tw-items-center tw-justify-center tw-gap-2 tw-text-center tw-p-3 tw-font-mono tw-font-bold tw-text-[10px] tw-uppercase tw-tracking-widest tw-text-[#daff0a] tw-border-[#daff0a]/40 hover:tw-text-[#daff0a] tw-transition-colors tw-no-underline" style="border-radius: 0px !important;">
-			<Icon name="status.shield-check" size={14} class="tw-text-[#daff0a]" />
-			<span>MISSION CONTROL</span>
+	<!-- Top Navigation Section (3-section grid) -->
+	<div class="tw-col-span-12 tw-grid tw-grid-cols-3 tw-gap-4 tw-mb-2">
+		<a href="/coach/tactical" class="vanguard-panel dashboard-card tw-flex tw-items-center tw-justify-center tw-gap-2 tw-text-center tw-p-3 tw-font-mono tw-font-bold tw-text-[10px] tw-uppercase tw-tracking-widest tw-text-slate-400 hover:tw-text-[#14b8a6] tw-transition-colors tw-no-underline" style="border-radius: 0px !important;">
+			<Icon name="action.edit" size={14} class="tw-text-slate-400 group-hover:tw-text-[#14b8a6]" />
+			<span>WAR ROOM</span>
+		</a>
+		<a href="/coach/matchday" class="vanguard-panel dashboard-card tw-flex tw-items-center tw-justify-center tw-gap-2 tw-text-center tw-p-3 tw-font-mono tw-font-bold tw-text-[10px] tw-uppercase tw-tracking-widest tw-text-slate-400 hover:tw-text-[#14b8a6] tw-transition-colors tw-no-underline" style="border-radius: 0px !important;">
+			<Icon name="data.activity" size={14} class="tw-text-slate-400 group-hover:tw-text-[#14b8a6]" />
+			<span>MATCH DAY</span>
 		</a>
 		<a href="/coach/logistics" class="vanguard-panel dashboard-card tw-flex tw-items-center tw-justify-center tw-gap-2 tw-text-center tw-p-3 tw-font-mono tw-font-bold tw-text-[10px] tw-uppercase tw-tracking-widest tw-text-slate-400 hover:tw-text-[#14b8a6] tw-transition-colors tw-no-underline" style="border-radius: 0px !important;">
 			<Icon name="user.group" size={14} class="tw-text-slate-400 group-hover:tw-text-[#14b8a6]" />

--- a/src/routes/(app)/coach/dashboard/DashboardEngine.svelte.ts
+++ b/src/routes/(app)/coach/dashboard/DashboardEngine.svelte.ts
@@ -20,6 +20,10 @@ export class DashboardEngine {
 		return (authStore.user?.email || '').trim();
 	}
 
+	get userUid() {
+		return authStore.user?.uid || '';
+	}
+
 	get clearanceStep() {
 		return deriveCoachClearanceStep(
 			/** @type {import('$lib/types/backgroundCheck.js').ClearanceDoc|undefined} */ (
@@ -42,8 +46,8 @@ export class DashboardEngine {
 	get myTeams() {
 		if (!teamsStore.loaded) return [];
 		if (this.role === 'super_admin' || this.role === 'global_admin') return teamsStore.teams.slice();
-		if (!this.userEmail) return [];
-		return teamsStore.getCoachTeams(this.userEmail);
+		if (!this.userEmail && !this.userUid) return [];
+		return teamsStore.getCoachTeams(this.userEmail, this.userUid);
 	}
 
 	get effectiveTeamId() {

--- a/src/routes/(app)/coach/organizations/+page.svelte
+++ b/src/routes/(app)/coach/organizations/+page.svelte
@@ -16,13 +16,14 @@
 	});
 
 	const userEmail = $derived((authStore.user?.email || '').trim());
+	const userUid = $derived(authStore.user?.uid || '');
 	const role = $derived(authStore.role);
 
 	const myTeams = $derived.by(() => {
 		if (!teamsStore.loaded) return [];
 		if (role === 'super_admin' || role === 'global_admin') return teamsStore.teams.slice();
-		if (!userEmail) return [];
-		return teamsStore.getCoachTeams(userEmail);
+		if (!userEmail && !userUid) return [];
+		return teamsStore.getCoachTeams(userEmail, userUid);
 	});
 
 	const affiliatedClubs = $derived.by(() => {


### PR DESCRIPTION
🎯 What
Fixed a team visibility issue in the Coach OS where teams assigned to a coach via uid were not populating in the store. Replaced the incorrect `coachUid` Firestore query string with the correct `coachId` field and updated the internal `getCoachTeams` array filtering to check for matching `uid`.

Additionally, updated the dashboard tabs on the Coach OS `Mission Control` page (`DashboardArena.svelte`) to strictly feature three buttons: War Room, Match Day, and Team Ops, replacing the previous Mission Control link without destructively affecting the global `workspaceNav` sidebars (resolving a visual regression).

💡 Why
Coach team assignment failed due to an incorrect database schema query parameter (`coachUid` rather than `coachId`), blocking coach onboarding and access to their designated telemetry.

✅ Verification
- Validated via tests that `teamsStore.getCoachTeams` operates as expected with uids.
- Visual inspection via Playwright confirmed the quick action tabs render strictly as War Room, Match Day, and Team Ops in the dashboard header, while leaving the sidebar intact.
- `pnpm run check` passes with 0 Svelte errors.

✨ Result
Coaches assigned strictly via UI-generated UIDs will now properly fetch their team roster metrics across all associated dashboard components, and navigation is explicitly styled to specifications.

---
*PR created automatically by Jules for task [12428679921034676691](https://jules.google.com/task/12428679921034676691) started by @blueneekone*