### PR TITLE
🧹 fix(commissioner): visual audit & self-heal for Commissioner OS

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,7 +11,7 @@
    * Verified `impersonateUserFn` security claims and route mappings. Patch implemented to prevent unauthenticated client modifications [cite: 361].
 
 2. **Commissioner OS (State Federation)**: 🟢 **READY**
-   * Multi-Tenant custom claims isolated. "God-mode" analytics metrics strictly scoped by regional boundaries to prevent cross-tenant leakages [cite: 361, 427, 428].
+   * Multi-Tenant custom claims isolated. "God-mode" analytics metrics strictly scoped by regional boundaries to prevent cross-tenant leakages [cite: 361, 427, 428]. Visual audit completed; radioactive yellow (#daff0a) remediated to compliant Data Cyan (#14b8a6) accents across VanguardPrism and Commissioner OS dashboards.
 
 3. **Director OS (B2B Revenue Engine)**: 🟢 **READY**
    * CSV Roster Import ("The Vampire Importer") throttled and capped at atomic batches of 500 writes to protect Firestore database locks [cite: 132, 427].

--- a/src/lib/components/commissioner/VanguardPrism.svelte
+++ b/src/lib/components/commissioner/VanguardPrism.svelte
@@ -138,8 +138,8 @@
 		<!-- Data Polygon -->
 		<polygon
 			{points}
-			fill="rgba(218, 255, 10, 0.15)"
-			stroke="#daff0a"
+			fill="rgba(20, 184, 166, 0.15)"
+			stroke="#14b8a6"
 			stroke-width="4"
 			class="data-polygon"
 			filter="url(#neonBloom)"
@@ -153,7 +153,7 @@
 				cy={y}
 				r="6"
 				fill="#000000"
-				stroke="#daff0a"
+				stroke="#14b8a6"
 				stroke-width="4"
 				filter="url(#neonBloom)"
 			/>

--- a/src/routes/(app)/commissioner/dashboard/CommissionerDashboardArena.svelte
+++ b/src/routes/(app)/commissioner/dashboard/CommissionerDashboardArena.svelte
@@ -105,7 +105,7 @@
 						</a>
 						<button
 							type="button"
-							class="tw-px-3 tw-py-2 tw-text-xs tw-font-mono tw-font-bold tw-tracking-wider tw-uppercase tw-bg-transparent tw-border tw-border-[#daff0a] tw-text-[#daff0a] hover:tw-bg-[#daff0a] hover:tw-text-black tw-transition-colors tw-flex tw-items-center tw-justify-between cursor-pointer tw-rounded-none"
+							class="tw-px-3 tw-py-2 tw-text-xs tw-font-mono tw-font-bold tw-tracking-wider tw-uppercase tw-bg-transparent tw-border tw-border-[#14b8a6] tw-text-[#14b8a6] hover:tw-bg-[#14b8a6] hover:tw-text-black tw-transition-colors tw-flex tw-items-center tw-justify-between cursor-pointer tw-rounded-none"
 							onclick={() => engine.fetchFederationData()}
 						>
 							<span class="tw-flex tw-items-center tw-gap-2">

--- a/src/routes/(app)/commissioner/dashboard/CommissionerDashboardHUD.svelte
+++ b/src/routes/(app)/commissioner/dashboard/CommissionerDashboardHUD.svelte
@@ -34,7 +34,7 @@
 			<div class="tw-flex tw-flex-col tw-items-end">
 				<span class="tw-text-[10px] tw-font-sans tw-text-slate-400 tw-uppercase tw-font-bold tw-tracking-widest">Network Status</span>
 				{#if engine.isLoading}
-					<span class="tw-text-[#daff0a] tw-font-mono tw-text-xs tw-font-bold tw-flex tw-items-center tw-gap-1">
+					<span class="tw-text-[#14b8a6] tw-font-mono tw-text-xs tw-font-bold tw-flex tw-items-center tw-gap-1">
 						<Icon name={"status.loading" as IconName} size={12} class="tw-animate-spin" />
 						SYNCING...
 					</span>
@@ -55,7 +55,7 @@
 
 			<button
 				type="button"
-				class="tw-px-3 tw-py-1.5 tw-text-xs tw-font-mono tw-font-bold tw-tracking-widest tw-uppercase tw-rounded-none tw-border tw-border-[#daff0a] tw-bg-[#1E293B] tw-text-[#daff0a] hover:tw-bg-[#daff0a] hover:tw-text-black tw-transition-colors tw-flex tw-items-center tw-gap-2 cursor-pointer"
+				class="tw-px-3 tw-py-1.5 tw-text-xs tw-font-mono tw-font-bold tw-tracking-widest tw-uppercase tw-rounded-none tw-border tw-border-[#14b8a6] tw-bg-[#1E293B] tw-text-[#14b8a6] hover:tw-bg-[#14b8a6] hover:tw-text-black tw-transition-colors tw-flex tw-items-center tw-gap-2 cursor-pointer"
 				onclick={() => engine.fetchFederationData()}
 				title="Refresh Federation Telemetry"
 			>


### PR DESCRIPTION
Completed visual audit and self-heal for COMMISSIONER OS:
1. Replaced non-compliant radioactive yellow (`#daff0a`) accents in `VanguardPrism.svelte`, `CommissionerDashboardArena.svelte`, and `CommissionerDashboardHUD.svelte` with compliant Data Cyan (`#14b8a6`).
2. Executed Playwright E2E visual tests and verified frontend screenshots.
3. Confirmed all Commissioner OS unit tests and local test suites pass.
4. Updated ROADMAP.md with completion status.

Fixes #457

---
*PR created automatically by Jules for task [5324314779797880310](https://jules.google.com/task/5324314779797880310) started by @blueneekone*