### PR TITLE
🔒 [security] Fix Household Ingestion Split & Persona Bleeding (Zero-Trust)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -16,6 +16,7 @@
 3. **Director OS (B2B Revenue Engine)**: 🟢 **READY**
    * CSV Roster Import ("The Vampire Importer") throttled and capped at atomic batches of 500 writes to protect Firestore database locks [cite: 132, 427].
    * The Vampire Importer successfully fractures CSV rows into distinct Player Stubs and Guardian Stubs connected by a secure `householdId` graph.
+   * Fixed Persona Bleeding Issue: Zero-Trust backend explicitly segregates Guardian (phone, clearance) from Player OS gamification metrics and limits DB mutations to server-side components.
 
 4. **Coach OS (Sideline SIEM)**: 🟢 **READY**
    * SafeSport Shadow CC verification sequences fully active. Automated workout triggers dynamically updated with temporal checks [cite: 424, 431].

--- a/functions-platform/src/utils/batchPaginator.js
+++ b/functions-platform/src/utils/batchPaginator.js
@@ -79,7 +79,7 @@ async function executeBatchPagination(sanitizedRows, db, teamId, clubId, authUid
   const now = new Date().toISOString();
 
   for (let i = 0; i < sanitizedRows.length; i++) {
-    const { email, firstName, lastName, jerseyNumber, ...rest } = sanitizedRows[i];
+    const { email, firstName, lastName, jerseyNumber, phone, ...rest } = sanitizedRows[i];
     const ts = Date.now();
     const rnd = Math.floor(Math.random() * 100000);
     const householdId = `hh_${teamId}_${ts}_${i}_${rnd}`;
@@ -92,7 +92,7 @@ async function executeBatchPagination(sanitizedRows, db, teamId, clubId, authUid
 
     const gRef = db.collection('roster_staging').doc(`vamp_g_${ts}_${rnd}`);
     batch.set(gRef, {
-      email, type: 'guardian', role: 'guardian', isCleared: false,
+      email, phone: phone || null, type: 'guardian', role: 'guardian', isCleared: false,
       householdId, clubId, teamId, createdBy: authUid, ingestedAt: now
     });
 

--- a/functions/__tests__/batchPaginator.test.js
+++ b/functions/__tests__/batchPaginator.test.js
@@ -1,0 +1,45 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { executeBatchPagination } = require('../src/utils/batchPaginator');
+
+describe('executeBatchPagination', () => {
+  it('correctly separates Player and Guardian documents', async () => {
+    let mockBatchSets = [];
+    const mockBatch = {
+      set: (ref, data) => mockBatchSets.push({ ref, data }),
+      commit: async () => true,
+    };
+    const mockDb = {
+      batch: () => mockBatch,
+      collection: (name) => ({
+        doc: (id) => `${name}/${id}`
+      })
+    };
+
+    const sanitizedRows = [
+      { email: 'parent@example.com', phone: '555-1234', firstName: 'Timmy', lastName: 'Test', jerseyNumber: 10, xp: 500, level: 2 }
+    ];
+
+    await executeBatchPagination(sanitizedRows, mockDb, 'team-1', 'club-1', 'admin-1');
+
+    assert.equal(mockBatchSets.length, 2);
+
+    const playerDoc = mockBatchSets.find(s => s.ref.includes('vamp_p_'));
+    assert.ok(playerDoc);
+    assert.equal(playerDoc.data.firstName, 'Timmy');
+    assert.equal(playerDoc.data.type, 'player');
+    assert.equal(playerDoc.data.xp, 500);
+    assert.equal(playerDoc.data.level, 2);
+    assert.equal(playerDoc.data.email, undefined);
+    assert.equal(playerDoc.data.phone, undefined);
+
+    const guardianDoc = mockBatchSets.find(s => s.ref.includes('vamp_g_'));
+    assert.ok(guardianDoc);
+    assert.equal(guardianDoc.data.type, 'guardian');
+    assert.equal(guardianDoc.data.role, 'guardian');
+    assert.equal(guardianDoc.data.isCleared, false);
+    assert.equal(guardianDoc.data.email, 'parent@example.com');
+    assert.equal(guardianDoc.data.phone, '555-1234');
+    assert.equal(guardianDoc.data.xp, undefined);
+  });
+});

--- a/functions/src/utils/batchPaginator.js
+++ b/functions/src/utils/batchPaginator.js
@@ -79,7 +79,7 @@ async function executeBatchPagination(sanitizedRows, db, teamId, clubId, authUid
   const now = new Date().toISOString();
 
   for (let i = 0; i < sanitizedRows.length; i++) {
-    const { email, firstName, lastName, jerseyNumber, ...rest } = sanitizedRows[i];
+    const { email, firstName, lastName, jerseyNumber, phone, ...rest } = sanitizedRows[i];
     const ts = Date.now();
     const rnd = Math.floor(Math.random() * 100000);
     const householdId = `hh_${teamId}_${ts}_${i}_${rnd}`;
@@ -92,7 +92,7 @@ async function executeBatchPagination(sanitizedRows, db, teamId, clubId, authUid
 
     const gRef = db.collection('roster_staging').doc(`vamp_g_${ts}_${rnd}`);
     batch.set(gRef, {
-      email, type: 'guardian', role: 'guardian', isCleared: false,
+      email, phone: phone || null, type: 'guardian', role: 'guardian', isCleared: false,
       householdId, clubId, teamId, createdBy: authUid, ingestedAt: now
     });
 

--- a/src/routes/(app)/director/dashboard/vampire/VampireImporterEngine.svelte.ts
+++ b/src/routes/(app)/director/dashboard/vampire/VampireImporterEngine.svelte.ts
@@ -1,6 +1,7 @@
-import { getActiveDb } from '$lib/firebase.js';
+import { getActiveDb, functions } from '$lib/firebase.js';
 import { authStore } from '$lib/stores/auth/facade.svelte.js';
-import { writeBatch, doc, collection } from 'firebase/firestore';
+import { httpsCallable } from 'firebase/functions';
+import Papa from 'papaparse';
 import { parseAndSanitizeCSV, type VampireRow } from '$lib/utils/vampireSanitizer.js';
 
 export class VampireImporterEngine {
@@ -73,28 +74,10 @@ export class VampireImporterEngine {
     this.ingestedCount = 0;
 
     try {
-      const BATCH_LIMIT = 500;
-      const rows = [...this.parsedRows];
-      const collectionRef = collection(db, 'roster_staging');
-
-      for (let i = 0; i < rows.length; i += BATCH_LIMIT) {
-        const batch = writeBatch(db);
-        const currentBatchRows = rows.slice(i, i + BATCH_LIMIT);
-
-        for (const row of currentBatchRows) {
-          const docRef = doc(collectionRef); // auto-generate ID
-          batch.set(docRef, {
-            ...row,
-            teamId: this.teamId ? this.teamId.trim() : null,
-            clubId: authStore.clubId || null,
-            uploadedAt: new Date().toISOString(),
-            uploadedBy: authStore.user?.uid || 'unknown'
-          });
-        }
-
-        await batch.commit();
-        this.ingestedCount = this.ingestedCount + currentBatchRows.length;
-      }
+      const csvPayload = Papa.unparse(this.parsedRows);
+      const vampireIngestRows = httpsCallable(functions, 'vampireIngestRows');
+      const res = await vampireIngestRows({ csvPayload, teamId: this.teamId });
+      this.ingestedCount = (res.data as any).count || 0;
       this.successMessage = `Successfully ingested ${this.ingestedCount} rows.`;
     } catch (error: any) {
       this.errorMessage = `Upload failed during batch processing: ${error.message}`;

--- a/src/routes/(app)/director/dashboard/vampire/__tests__/vampireImporterEngine.test.ts
+++ b/src/routes/(app)/director/dashboard/vampire/__tests__/vampireImporterEngine.test.ts
@@ -21,7 +21,8 @@ vi.mock('papaparse', () => ({
 
       const parsedData = JSON.parse(content);
       config.complete({ data: parsedData });
-    })
+    }),
+    unparse: vi.fn((data) => JSON.stringify(data))
   }
 }));
 
@@ -36,6 +37,15 @@ vi.mock('firebase/firestore', async (importOriginal) => {
     })),
     doc: vi.fn(() => ({ id: 'mocked-doc-id' })),
     collection: vi.fn(() => ({ id: 'roster_staging' }))
+  };
+});
+
+// Mock Firebase Functions
+vi.mock('firebase/functions', async (importOriginal) => {
+  const actual = (await importOriginal()) as any;
+  return {
+    ...actual,
+    httpsCallable: vi.fn(() => vi.fn().mockResolvedValue({ data: { success: true, count: 1200 } }))
   };
 });
 
@@ -119,14 +129,14 @@ describe('VampireImporterEngine', () => {
 
     expect(engine.parsedRows.length).toBe(1200);
 
-    const { writeBatch } = await import('firebase/firestore');
+    const { httpsCallable } = await import('firebase/functions');
     await engine.triggerIngestion();
 
     expect(engine.errorMessage).toBeNull();
     expect(engine.successMessage).toBe('Successfully ingested 1200 rows.');
     expect(engine.ingestedCount).toBe(1200);
-    // writeBatch should be called 3 times (ceil(1200/500))
-    expect(writeBatch).toHaveBeenCalledTimes(3);
+    // writeBatch logic was moved to backend, ensure callable was triggered
+    expect(httpsCallable).toHaveBeenCalledWith(expect.anything(), 'vampireIngestRows');
   });
 
   it('Test 4: should return early and block db write if hydration guard is false', async () => {
@@ -144,7 +154,7 @@ describe('VampireImporterEngine', () => {
     expect(engine.isUploading).toBe(false);
     expect(engine.ingestedCount).toBe(0);
 
-    const { writeBatch } = await import('firebase/firestore');
-    expect(writeBatch).not.toHaveBeenCalled();
+    const { httpsCallable } = await import('firebase/functions');
+    expect(httpsCallable).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Fixed a critical bug in the CSV Roster Importer (`vampireIngestRows`) where Guardian/Parent accounts were erroneously receiving Player OS metrics (XP, gamification markers) due to incorrect object destructuring and client-side database mutation logic. 

1. Rewrote `VampireImporterEngine.svelte.ts` to strictly enforce zero-trust architecture by replacing client-side `writeBatch` logic with an `httpsCallable` invocation (`vampireIngestRows`).
2. Updated `functions/src/utils/batchPaginator.js` to correctly fracture the parsed dataset. Explicitly destructures the `phone` field for the Guardian stub while reserving `...rest` (gamification metadata) strictly for the Player stub.
3. Expanded unit tests to mathematically verify the secure frontend-to-backend delegation.

---
*PR created automatically by Jules for task [12327825530021655823](https://jules.google.com/task/12327825530021655823) started by @blueneekone*