### PR TITLE
fix(sw): bypass non-GET requests and Firebase auth endpoints in service worker

### DIFF
--- a/src/lib/components/shell/PlayerActionInbox.svelte
+++ b/src/lib/components/shell/PlayerActionInbox.svelte
@@ -155,6 +155,8 @@
 		letter-spacing: 0.07em;
 		color: var(--text-secondary);
 		margin-bottom: 12px;
+	}
+
 	.pai__muted {
 		margin: 0;
 		font-size: 13px;

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -59,7 +59,10 @@ const BYPASS_REGEXES = [
 	/firestore\.googleapis\.com/,
 	/cloudfunctions\.net/,
 	/__\/auth/,
-	/securetoken\.googleapis\.com/
+	/securetoken\.googleapis\.com/,
+	/identitytoolkit\.googleapis\.com/,
+	/firebaseinstallations\.googleapis\.com/,
+	/fcmregistrations\.googleapis\.com/
 ];
 
 const sw = self as unknown as ServiceWorkerGlobalScope;
@@ -207,10 +210,18 @@ sw.addEventListener('activate', (event: ExtendableEvent) => {
 
 sw.addEventListener('fetch', (event: FetchEvent) => {
 	const req = event.request;
+
+	// Non-GET requests (POST, PUT, DELETE, PATCH, etc.) can never be cached in CacheStorage.
+	// Bypassing directly to native browser networking guarantees authentication,
+	// passkeys, Firebase Auth, and API mutations never fail with "Request method 'POST' is unsupported".
+	if (req.method !== 'GET') {
+		return;
+	}
+
 	const url = new URL(req.url);
 
 	// Immediately exit and hand off to native browser networking for Firebase / Firestore APIs
-	if (BYPASS_REGEXES.some((regex) => regex.test(url.href))) {
+	if (BYPASS_REGEXES.some((regex) => regex.test(url.href)) || isFirebaseEndpoint(url)) {
 		return;
 	}
 
@@ -220,7 +231,7 @@ sw.addEventListener('fetch', (event: FetchEvent) => {
 			caches.open(RUNTIME_CACHE).then(async (cache) => {
 				try {
 					const fresh = await fetch(req);
-					if (fresh.status === 200) {
+					if (fresh.status === 200 && req.method === 'GET') {
 						cache.put(req, fresh.clone());
 					}
 					return fresh;
@@ -242,7 +253,7 @@ sw.addEventListener('fetch', (event: FetchEvent) => {
 				const cached = await cache.match(req);
 				if (cached) return cached;
 				const fresh = await fetch(req);
-				if (fresh.status === 200) {
+				if (fresh.status === 200 && req.method === 'GET') {
 					cache.put(req, fresh.clone());
 				}
 				return fresh;
@@ -259,8 +270,6 @@ sw.addEventListener('fetch', (event: FetchEvent) => {
 		return;
 	}
 
-	if (event.request.method !== 'GET') return;
-
 	// Sprint 2.7: Stale-While-Revalidate for offline routes
 	const isOfflineData = url.pathname.endsWith('__data.json') && OFFLINE_ROUTES.some((r) => url.pathname.replace(/__data\.json$/, '').startsWith(r));
 	if (isOfflineRoute(url) || isOfflineData) {
@@ -268,7 +277,7 @@ sw.addEventListener('fetch', (event: FetchEvent) => {
 			caches.open(RUNTIME_CACHE).then(async (cache) => {
 				const cachedResponse = await cache.match(req);
 				const networkPromise = fetch(req).then((networkResponse) => {
-					if (networkResponse && networkResponse.status === 200) {
+					if (networkResponse && networkResponse.status === 200 && req.method === 'GET') {
 						cache.put(req, networkResponse.clone());
 					}
 					return networkResponse;


### PR DESCRIPTION
Bypasses all non-GET HTTP requests (POST, PUT, DELETE, PATCH) directly to browser networking at the start of the service worker fetch handler, preventing the browser Cache API from throwing 'TypeError: Failed to execute put on Cache: Request method POST is unsupported' during authentication, passkey login, and API mutations. Also explicitly bypasses Firebase auth/token/installations endpoints.