### PR TITLE
fix(auth): add same-origin-allow-popups COOP headers and bound auth wait loops

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -29,6 +29,10 @@
             "value": "nosniff"
           },
           {
+            "key": "Cross-Origin-Opener-Policy",
+            "value": "same-origin-allow-popups"
+          },
+          {
             "key": "X-Frame-Options",
             "value": "DENY"
           },

--- a/server.js
+++ b/server.js
@@ -47,7 +47,8 @@ function serveFile(res, filePath, statusCode = 200) {
 	res.writeHead(statusCode, {
 		'Content-Type': contentType,
 		'Cache-Control': cacheControl,
-		'X-Content-Type-Options': 'nosniff'
+		'X-Content-Type-Options': 'nosniff',
+		'Cross-Origin-Opener-Policy': 'same-origin-allow-popups'
 	});
 	fs.createReadStream(filePath).pipe(res);
 }

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -75,7 +75,8 @@
 					{ email: user.email, displayName: user.displayName, photoURL: user.photoURL ?? null, lastLogin: serverTimestamp() },
 					{ merge: true },
 				);
-				while (authStore.isLoading) {
+				let maxWait = 40;
+				while (authStore.isLoading && --maxWait > 0) {
 					await new Promise((r) => setTimeout(r, 50));
 				}
 				await navigateAfterLogin({ replaceState: true });
@@ -93,7 +94,8 @@
 		googleError = '';
 		await loginEngine.loginWithPasskey();
 		if (loginEngine.error) { navigating = false; return; }
-		while (authStore.isLoading) {
+		let maxWait = 40;
+		while (authStore.isLoading && --maxWait > 0) {
 			await new Promise((r) => setTimeout(r, 50));
 		}
 		await navigateAfterLogin({ replaceState: true });

--- a/vite.config.js
+++ b/vite.config.js
@@ -13,6 +13,11 @@ export default defineConfig(({ mode }) => ({
 			ignored: ['**/recordings/**', '**/static/videos/**', '**/scripts/**']
 		}
 	},
+	preview: {
+		headers: {
+			'Cross-Origin-Opener-Policy': 'same-origin-allow-popups'
+		}
+	},
 
 	/**
 	 * Sprint 1.1 — content-hash asset versioning (.cursorrules asset_versioning).


### PR DESCRIPTION
## Architectural Summary
- Sets 'Cross-Origin-Opener-Policy': 'same-origin-allow-popups' across server.js, firebase.json, and vite.config.js (preview) to permit OAuth / Google Auth popup window contexts to communicate and cleanly close.
- Bounds authStore.isLoading wait loops in login/+page.svelte to prevent potential hanging.