### PR TITLE
fix: refine import skipping logic in python workspace cleanup script

### DIFF
--- a/workspace_cleanup_and_heal.py
+++ b/workspace_cleanup_and_heal.py
@@ -152,17 +152,15 @@ def heal_local_codebase():
                             continue
 
                         if re.match(r"^\s*import\b", line):
-                            if ";" not in stripped and "from" not in stripped:
+                            if ";" not in stripped and not re.search(r"\bfrom\b", stripped):
                                 in_import = True
                             continue
                         if in_import:
-                            if ";" in stripped or "from" in stripped:
+                            if ";" in stripped or re.search(r"\bfrom\b", stripped):
                                 in_import = False
                             continue
 
                         if stripped.startswith("//") or stripped.startswith("*") or stripped.startswith("/*"):
-                            continue
-                        if "import" in line or "export" in line or "from" in line:
                             continue
 
                         # ONLY match if it is an actual function listener / call site in an active execution block


### PR DESCRIPTION
Fixes an issue in the `workspace_cleanup_and_heal.py` script where the SvelteKit SSR session cookie sync modification logic was failing to find valid execution blocks. 

The previous logic aggressively skipped any line containing `"import"`, `"export"`, or `"from"`, which would incorrectly skip the very lines it was supposed to modify if they contained `export` or `from` outside of actual module import headers.

This patch implements a proper regex based search using `\bfrom\b` to determine the end of multiline imports, and removes the naive block-skip string matching entirely, correctly delegating the actual patching to the specific function call signature check (`onIdTokenChanged`).

---
*PR created automatically by Jules for task [5684933897854431491](https://jules.google.com/task/5684933897854431491) started by @blueneekone*