### PR TITLE
🔒 Fix missing AppCheck enforcement in cvBiomechanicsVerifier

### DIFF
--- a/functions/cvBiomechanicsVerifier.js
+++ b/functions/cvBiomechanicsVerifier.js
@@ -1,7 +1,7 @@
 const { onCall, HttpsError } = require('firebase-functions/v2/https');
 const logger = require('firebase-functions/logger');
 
-exports.cvBiomechanicsVerifier = onCall({ region: 'us-east1' }, async (request) => {
+exports.cvBiomechanicsVerifier = onCall({ region: 'us-east1', enforceAppCheck: true }, async (request) => {
 	if (!request.auth) {
 		throw new HttpsError('unauthenticated', 'Sign in required.');
 	}


### PR DESCRIPTION
🎯 **What:** Adds Firebase AppCheck enforcement to the `cvBiomechanicsVerifier` cloud function.
⚠️ **Risk:** Without AppCheck, the API endpoint is vulnerable to abuse by unverified clients, which could lead to unauthorized mock analysis runs, potential denial of service, and undue stress on backend resources.
🛡️ **Solution:** Added the `enforceAppCheck: true` option in the `onCall` function configuration, ensuring requests must originate from verified apps.

---
*PR created automatically by Jules for task [5802906786410508122](https://jules.google.com/task/5802906786410508122) started by @blueneekone*