### PR TITLE
🧪 [testing improvement] Add tests for isDefaultCell function

### DIFF
--- a/src/lib/types/__tests__/cells.test.ts
+++ b/src/lib/types/__tests__/cells.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { isDefaultCell, resolveCellId, DEFAULT_CELL_ID } from '../cells.js';
+
+describe('cells type definitions and helpers', () => {
+	describe('resolveCellId', () => {
+		it('resolves explicit default cell id', () => {
+			expect(resolveCellId(DEFAULT_CELL_ID)).toBe(DEFAULT_CELL_ID);
+			expect(resolveCellId('default')).toBe(DEFAULT_CELL_ID);
+		});
+
+		it('resolves empty or whitespace inputs to default', () => {
+			expect(resolveCellId('')).toBe(DEFAULT_CELL_ID);
+			expect(resolveCellId('   ')).toBe(DEFAULT_CELL_ID);
+			expect(resolveCellId('\t\n')).toBe(DEFAULT_CELL_ID);
+		});
+
+		it('resolves non-string inputs to default', () => {
+			expect(resolveCellId(null)).toBe(DEFAULT_CELL_ID);
+			expect(resolveCellId(undefined)).toBe(DEFAULT_CELL_ID);
+			expect(resolveCellId(123)).toBe(DEFAULT_CELL_ID);
+			expect(resolveCellId({})).toBe(DEFAULT_CELL_ID);
+		});
+
+		it('trims and preserves valid dedicated cell IDs', () => {
+			expect(resolveCellId('cell-use1-001')).toBe('cell-use1-001');
+			expect(resolveCellId('  cell-use1-002  ')).toBe('cell-use1-002');
+		});
+	});
+
+	describe('isDefaultCell', () => {
+		it('returns true for exact default cell match', () => {
+			expect(isDefaultCell(DEFAULT_CELL_ID)).toBe(true);
+		});
+
+		it('returns true for literal "default" and whitespace', () => {
+			expect(isDefaultCell('default')).toBe(true);
+			expect(isDefaultCell('')).toBe(true);
+			expect(isDefaultCell('  ')).toBe(true);
+		});
+
+		it('returns false for dedicated cell IDs', () => {
+			expect(isDefaultCell('cell-use1-001')).toBe(false);
+			expect(isDefaultCell('cell-usc1-042')).toBe(false);
+		});
+	});
+});


### PR DESCRIPTION
🎯 **What:** Added tests for the `isDefaultCell` and `resolveCellId` functions inside `src/lib/types/cells.ts`.
📊 **Coverage:** The test suite covers default cell explicit matches (e.g. `'(default)'` and `'default'`), empty and whitespace input coercion, non-string type fallbacks, and standard dedicated cell identifiers (e.g. `'cell-use1-001'`).
✨ **Result:** Enhanced test coverage and reliability for cell-based routing helpers by ensuring input resolutions and routing checks perform predictably under all standard inputs.

---
*PR created automatically by Jules for task [3354616905225975900](https://jules.google.com/task/3354616905225975900) started by @blueneekone*