### PR TITLE
🧪 Add test coverage for filterClubsBySport

### DIFF
--- a/src/lib/admin/__tests__/organizationsFilters.test.ts
+++ b/src/lib/admin/__tests__/organizationsFilters.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+	filterClubsBySport,
 	filterOrganizations,
 	tierForClub,
 	toggleInList,
@@ -52,5 +53,24 @@ describe('organizationsFilters', () => {
 		});
 		expect(filtered).toHaveLength(1);
 		expect(filtered[0]?.id).toBe('tx-club');
+	});
+
+	describe('filterClubsBySport', () => {
+		it('returns all clubs when sportTab is "all"', () => {
+			const filtered = filterClubsBySport(SAMPLE, 'all');
+			expect(filtered).toHaveLength(2);
+			expect(filtered).toEqual(SAMPLE);
+		});
+
+		it('returns clubs matching a specific normalized sport', () => {
+			const filtered = filterClubsBySport(SAMPLE, 'soccer');
+			expect(filtered).toHaveLength(1);
+			expect(filtered[0]?.id).toBe('tx-club');
+		});
+
+		it('returns empty array if no clubs match the sport', () => {
+			const filtered = filterClubsBySport(SAMPLE, 'football' as any);
+			expect(filtered).toHaveLength(0);
+		});
 	});
 });


### PR DESCRIPTION
🎯 **What:** Added missing test coverage for `filterClubsBySport` in `src/lib/admin/organizationsFilters.ts`.
📊 **Coverage:** Covered scenarios for 'all' selection, specific sport match ('soccer'), and no matches found ('football').
✨ **Result:** Improved test suite reliability for the administrative organizations filter utility.

---
*PR created automatically by Jules for task [17595824747431288779](https://jules.google.com/task/17595824747431288779) started by @blueneekone*