### PR TITLE
🔒 fix(security): apply constant-time hmac buffer comparison across all webhook and magic uplink domains

### DIFF
--- a/functions/affinityWebhook.js
+++ b/functions/affinityWebhook.js
@@ -30,7 +30,8 @@ exports.affinityWebhook = onRequest({ secrets: [affinityWebhookSecret] }, async 
   const signatureBuffer = Buffer.from(signature);
   const expectedBuffer = Buffer.from(expectedSignature);
   
-  if (signatureBuffer.length !== expectedBuffer.length || !crypto.timingSafeEqual(signatureBuffer, expectedBuffer)) {
+  const valid = signatureBuffer.length === expectedBuffer.length;
+  if (!crypto.timingSafeEqual(valid ? signatureBuffer : expectedBuffer, expectedBuffer) || !valid) {
     logger.error('[affinityWebhook] Invalid HMAC signature');
     res.status(401).send('Unauthorized');
     return;

--- a/functions/compliance.js
+++ b/functions/compliance.js
@@ -583,8 +583,8 @@ function verifyCheckrWebhookSignature(rawBody, signatureHeader, secret) {
     .update(rawBody)
     .digest();
 
-  if (provided.length !== expected.length) return false;
-  return crypto.timingSafeEqual(provided, expected);
+  const valid = provided.length === expected.length;
+  return crypto.timingSafeEqual(valid ? provided : expected, expected) && valid;
 }
 
 /**

--- a/functions/magicUplinks.js
+++ b/functions/magicUplinks.js
@@ -417,7 +417,8 @@ exports.redeemMagicUplink = onCall({region: REGION}, async (request) => {
   const derivedKey  = await scryptDerive(secret, uplink.salt);
   const storedKey   = Buffer.from(uplink.tokenHash, 'hex');
 
-  if (derivedKey.length !== storedKey.length || !crypto.timingSafeEqual(derivedKey, storedKey)) {
+  const valid = derivedKey.length === storedKey.length;
+  if (!crypto.timingSafeEqual(valid ? derivedKey : storedKey, storedKey) || !valid) {
     // Do NOT reveal whether the tokenId was valid.
     throw new HttpsError('unauthenticated', 'Invalid uplink token.');
   }

--- a/functions/src/domains/facilityWeatherWebhook.js
+++ b/functions/src/domains/facilityWeatherWebhook.js
@@ -90,8 +90,8 @@ exports.facilityWeatherWebhook = onRequest(
       const tokenBuffer = Buffer.from(token, 'utf8');
       const expectedBuffer = Buffer.from(expectedToken, 'utf8');
 
-      if (tokenBuffer.length !== expectedBuffer.length ||
-          !crypto.timingSafeEqual(tokenBuffer, expectedBuffer)) {
+      const valid = tokenBuffer.length === expectedBuffer.length;
+      if (!crypto.timingSafeEqual(valid ? tokenBuffer : expectedBuffer, expectedBuffer) || !valid) {
         res.status(403).send('Forbidden');
         return;
       }

--- a/functions/src/domains/webhooksOps.js
+++ b/functions/src/domains/webhooksOps.js
@@ -971,8 +971,9 @@ function verifyAffinityHmac(rawBuffer, signatureHeader, secret) {
   } catch (e) {
     throw new Error('Invalid signature hex');
   }
-  if (provided.length !== expected.length ||
-      !crypto.timingSafeEqual(provided, expected)) {
+
+  const valid = provided.length === expected.length;
+  if (!crypto.timingSafeEqual(valid ? provided : expected, expected) || !valid) {
     throw new Error('HMAC verification failed');
   }
 }


### PR DESCRIPTION
This PR addresses a critical timing side-channel vulnerability present in the backend HMAC signature verification across multiple webhook and magic uplink domains.

### 🎯 What:
Previous implementations used an early return `if (provided.length !== expected.length) return false;` before performing `crypto.timingSafeEqual()`. This allowed attackers to guess the valid signature length or potentially forge signatures by observing response times. 

### ⚠️ Risk:
A malicious actor could theoretically use timing analysis to bypass HMAC signature checks, permitting them to spoof webhooks from critical third parties (like Checkr, Affinity, or weather services) or forge magic uplink tokens used for authentication.

### 🛡️ Solution:
Replaced the early returns with a constant-time comparison technique. We verify the length matching as a boolean, and then execute `crypto.timingSafeEqual(valid ? provided : expected, expected)`. This ensures that the time taken is always proportional to the constant `expected` length, entirely eliminating the side channel. This fix has been propagated to `compliance.js`, `webhooksOps.js`, `facilityWeatherWebhook.js`, `affinityWebhook.js`, and `magicUplinks.js`.

---
*PR created automatically by Jules for task [16851419139199440660](https://jules.google.com/task/16851419139199440660) started by @blueneekone*