### PR TITLE
🔒 Fix timing leaks in crypto.timingSafeEqual across backend

### DIFF
--- a/functions-commerce/src/domains/webhooksOps.js
+++ b/functions-commerce/src/domains/webhooksOps.js
@@ -971,8 +971,13 @@ function verifyAffinityHmac(rawBuffer, signatureHeader, secret) {
   } catch (e) {
     throw new Error('Invalid signature hex');
   }
-  if (provided.length !== expected.length ||
-      !crypto.timingSafeEqual(provided, expected)) {
+
+  const isValidLength = provided.length === expected.length;
+  const compareBuffer = isValidLength ? provided : expected;
+  let isValid = crypto.timingSafeEqual(compareBuffer, expected);
+  isValid = isValid && isValidLength;
+
+  if (!isValid) {
     throw new Error('HMAC verification failed');
   }
 }

--- a/functions-commerce/ticketing.js
+++ b/functions-commerce/ticketing.js
@@ -391,10 +391,13 @@ exports.verifyScanToken = onCall(
           .update(`${ticketId}:${piId}`)
           .digest('base64url');
 
-      const tokenMatch = crypto.timingSafeEqual(
-          Buffer.from(qrToken),
-          Buffer.from(expectedHmac),
-      );
+      const providedBuffer = Buffer.from(qrToken);
+      const expectedBuffer = Buffer.from(expectedHmac);
+      const isValidLength = providedBuffer.length === expectedBuffer.length;
+      const compareBuffer = isValidLength ? providedBuffer : expectedBuffer;
+      let tokenMatch = crypto.timingSafeEqual(compareBuffer, expectedBuffer);
+      tokenMatch = tokenMatch && isValidLength;
+
       if (!tokenMatch) {
         return {valid: false, status: 'invalid'};
       }

--- a/functions-compliance/compliance.js
+++ b/functions-compliance/compliance.js
@@ -583,8 +583,10 @@ function verifyCheckrWebhookSignature(rawBody, signatureHeader, secret) {
     .update(rawBody)
     .digest();
 
-  if (provided.length !== expected.length) return false;
-  return crypto.timingSafeEqual(provided, expected);
+  const isValidLength = provided.length === expected.length;
+  const compareBuffer = isValidLength ? provided : expected;
+  let isValid = crypto.timingSafeEqual(compareBuffer, expected);
+  return isValid && isValidLength;
 }
 
 /**

--- a/functions-integrations/src/domains/facilityWeatherWebhook.js
+++ b/functions-integrations/src/domains/facilityWeatherWebhook.js
@@ -90,8 +90,12 @@ exports.facilityWeatherWebhook = onRequest(
       const tokenBuffer = Buffer.from(token, 'utf8');
       const expectedBuffer = Buffer.from(expectedToken, 'utf8');
 
-      if (tokenBuffer.length !== expectedBuffer.length ||
-          !crypto.timingSafeEqual(tokenBuffer, expectedBuffer)) {
+      const isValidLength = tokenBuffer.length === expectedBuffer.length;
+      const compareBuffer = isValidLength ? tokenBuffer : expectedBuffer;
+      let isValid = crypto.timingSafeEqual(compareBuffer, expectedBuffer);
+      isValid = isValid && isValidLength;
+
+      if (!isValid) {
         res.status(403).send('Forbidden');
         return;
       }

--- a/functions-platform/apiGateway.js
+++ b/functions-platform/apiGateway.js
@@ -228,20 +228,26 @@ async function verifyPartnerSignature(headers, rawBody) {
   // ── API key verification (constant-time scrypt comparison) ──────────────
   const scryptHash = getScryptHash();
   const candidateHash = await scryptHash(apiKey, partner.keySalt);
-  const mainMatch = crypto.timingSafeEqual(
-      Buffer.from(candidateHash, 'hex'),
-      Buffer.from(partner.apiKeyHash, 'hex'),
-  );
+
+  const mainCandidateBuffer = Buffer.from(candidateHash, 'hex');
+  const mainExpectedBuffer = Buffer.from(partner.apiKeyHash, 'hex');
+  const mainIsValidLength = mainCandidateBuffer.length === mainExpectedBuffer.length;
+  const mainCompareBuffer = mainIsValidLength ? mainCandidateBuffer : mainExpectedBuffer;
+  let mainMatch = crypto.timingSafeEqual(mainCompareBuffer, mainExpectedBuffer);
+  mainMatch = mainMatch && mainIsValidLength;
 
   let gracePeriodMatch = false;
   if (!mainMatch && partner.previousApiKeyHash && partner.previousApiKeyHashUntil) {
     const gracePeriodExpiry = new Date(partner.previousApiKeyHashUntil).getTime();
     if (Date.now() < gracePeriodExpiry) {
       const prevHash = await scryptHash(apiKey, partner.keySalt);
-      gracePeriodMatch = crypto.timingSafeEqual(
-          Buffer.from(prevHash, 'hex'),
-          Buffer.from(partner.previousApiKeyHash, 'hex'),
-      );
+
+      const prevCandidateBuffer = Buffer.from(prevHash, 'hex');
+      const prevExpectedBuffer = Buffer.from(partner.previousApiKeyHash, 'hex');
+      const prevIsValidLength = prevCandidateBuffer.length === prevExpectedBuffer.length;
+      const prevCompareBuffer = prevIsValidLength ? prevCandidateBuffer : prevExpectedBuffer;
+      gracePeriodMatch = crypto.timingSafeEqual(prevCompareBuffer, prevExpectedBuffer);
+      gracePeriodMatch = gracePeriodMatch && prevIsValidLength;
     }
   }
 
@@ -279,10 +285,12 @@ async function verifyPartnerSignature(headers, rawBody) {
 
   let sigMatch = false;
   try {
-    sigMatch = crypto.timingSafeEqual(
-        Buffer.from(bodySignatureHeader.toLowerCase(), 'hex'),
-        Buffer.from(expectedSig, 'hex'),
-    );
+    const providedBuffer = Buffer.from(bodySignatureHeader.toLowerCase(), 'hex');
+    const expectedBuffer = Buffer.from(expectedSig, 'hex');
+    const isValidLength = providedBuffer.length === expectedBuffer.length;
+    const compareBuffer = isValidLength ? providedBuffer : expectedBuffer;
+    sigMatch = crypto.timingSafeEqual(compareBuffer, expectedBuffer);
+    sigMatch = sigMatch && isValidLength;
   } catch {
     sigMatch = false;
   }

--- a/functions-rl/tremendous.js
+++ b/functions-rl/tremendous.js
@@ -224,10 +224,15 @@ function verifyWebhookSignature(rawBody, signature, secret) {
 
   const received = sigParts.v1 || signature;
 
-  if (!crypto.timingSafeEqual(
-      Buffer.from(expected, 'hex'),
-      Buffer.from(received.padEnd(expected.length, '0').slice(0, expected.length), 'hex'),
-  )) {
+  const expectedBuffer = Buffer.from(expected, 'hex');
+  const receivedBuffer = Buffer.from(received.padEnd(expected.length, '0').slice(0, expected.length), 'hex');
+
+  const isValidLength = expectedBuffer.length === receivedBuffer.length;
+  const compareBuffer = isValidLength ? receivedBuffer : expectedBuffer;
+  let isValid = crypto.timingSafeEqual(compareBuffer, expectedBuffer);
+  isValid = isValid && isValidLength;
+
+  if (!isValid) {
     throw new Error('Tremendous webhook signature mismatch');
   }
 }

--- a/functions/apiGateway.js
+++ b/functions/apiGateway.js
@@ -228,20 +228,26 @@ async function verifyPartnerSignature(headers, rawBody) {
   // ── API key verification (constant-time scrypt comparison) ──────────────
   const scryptHash = getScryptHash();
   const candidateHash = await scryptHash(apiKey, partner.keySalt);
-  const mainMatch = crypto.timingSafeEqual(
-      Buffer.from(candidateHash, 'hex'),
-      Buffer.from(partner.apiKeyHash, 'hex'),
-  );
+
+  const mainCandidateBuffer = Buffer.from(candidateHash, 'hex');
+  const mainExpectedBuffer = Buffer.from(partner.apiKeyHash, 'hex');
+  const mainIsValidLength = mainCandidateBuffer.length === mainExpectedBuffer.length;
+  const mainCompareBuffer = mainIsValidLength ? mainCandidateBuffer : mainExpectedBuffer;
+  let mainMatch = crypto.timingSafeEqual(mainCompareBuffer, mainExpectedBuffer);
+  mainMatch = mainMatch && mainIsValidLength;
 
   let gracePeriodMatch = false;
   if (!mainMatch && partner.previousApiKeyHash && partner.previousApiKeyHashUntil) {
     const gracePeriodExpiry = new Date(partner.previousApiKeyHashUntil).getTime();
     if (Date.now() < gracePeriodExpiry) {
       const prevHash = await scryptHash(apiKey, partner.keySalt);
-      gracePeriodMatch = crypto.timingSafeEqual(
-          Buffer.from(prevHash, 'hex'),
-          Buffer.from(partner.previousApiKeyHash, 'hex'),
-      );
+
+      const prevCandidateBuffer = Buffer.from(prevHash, 'hex');
+      const prevExpectedBuffer = Buffer.from(partner.previousApiKeyHash, 'hex');
+      const prevIsValidLength = prevCandidateBuffer.length === prevExpectedBuffer.length;
+      const prevCompareBuffer = prevIsValidLength ? prevCandidateBuffer : prevExpectedBuffer;
+      gracePeriodMatch = crypto.timingSafeEqual(prevCompareBuffer, prevExpectedBuffer);
+      gracePeriodMatch = gracePeriodMatch && prevIsValidLength;
     }
   }
 
@@ -279,10 +285,12 @@ async function verifyPartnerSignature(headers, rawBody) {
 
   let sigMatch = false;
   try {
-    sigMatch = crypto.timingSafeEqual(
-        Buffer.from(bodySignatureHeader.toLowerCase(), 'hex'),
-        Buffer.from(expectedSig, 'hex'),
-    );
+    const providedBuffer = Buffer.from(bodySignatureHeader.toLowerCase(), 'hex');
+    const expectedBuffer = Buffer.from(expectedSig, 'hex');
+    const isValidLength = providedBuffer.length === expectedBuffer.length;
+    const compareBuffer = isValidLength ? providedBuffer : expectedBuffer;
+    sigMatch = crypto.timingSafeEqual(compareBuffer, expectedBuffer);
+    sigMatch = sigMatch && isValidLength;
   } catch {
     sigMatch = false;
   }

--- a/functions/compliance.js
+++ b/functions/compliance.js
@@ -583,8 +583,10 @@ function verifyCheckrWebhookSignature(rawBody, signatureHeader, secret) {
     .update(rawBody)
     .digest();
 
-  if (provided.length !== expected.length) return false;
-  return crypto.timingSafeEqual(provided, expected);
+  const isValidLength = provided.length === expected.length;
+  const compareBuffer = isValidLength ? provided : expected;
+  let isValid = crypto.timingSafeEqual(compareBuffer, expected);
+  return isValid && isValidLength;
 }
 
 /**

--- a/functions/magicUplinks.js
+++ b/functions/magicUplinks.js
@@ -417,7 +417,12 @@ exports.redeemMagicUplink = onCall({region: REGION}, async (request) => {
   const derivedKey  = await scryptDerive(secret, uplink.salt);
   const storedKey   = Buffer.from(uplink.tokenHash, 'hex');
 
-  if (derivedKey.length !== storedKey.length || !crypto.timingSafeEqual(derivedKey, storedKey)) {
+  const isValidLength = derivedKey.length === storedKey.length;
+  const compareKey = isValidLength ? derivedKey : storedKey;
+  let isValid = crypto.timingSafeEqual(compareKey, storedKey);
+  isValid = isValid && isValidLength;
+
+  if (!isValid) {
     // Do NOT reveal whether the tokenId was valid.
     throw new HttpsError('unauthenticated', 'Invalid uplink token.');
   }

--- a/functions/src/domains/facilityWeatherWebhook.js
+++ b/functions/src/domains/facilityWeatherWebhook.js
@@ -90,8 +90,12 @@ exports.facilityWeatherWebhook = onRequest(
       const tokenBuffer = Buffer.from(token, 'utf8');
       const expectedBuffer = Buffer.from(expectedToken, 'utf8');
 
-      if (tokenBuffer.length !== expectedBuffer.length ||
-          !crypto.timingSafeEqual(tokenBuffer, expectedBuffer)) {
+      const isValidLength = tokenBuffer.length === expectedBuffer.length;
+      const compareBuffer = isValidLength ? tokenBuffer : expectedBuffer;
+      let isValid = crypto.timingSafeEqual(compareBuffer, expectedBuffer);
+      isValid = isValid && isValidLength;
+
+      if (!isValid) {
         res.status(403).send('Forbidden');
         return;
       }

--- a/functions/src/domains/webhooksOps.js
+++ b/functions/src/domains/webhooksOps.js
@@ -971,8 +971,13 @@ function verifyAffinityHmac(rawBuffer, signatureHeader, secret) {
   } catch (e) {
     throw new Error('Invalid signature hex');
   }
-  if (provided.length !== expected.length ||
-      !crypto.timingSafeEqual(provided, expected)) {
+
+  const isValidLength = provided.length === expected.length;
+  const compareBuffer = isValidLength ? provided : expected;
+  let isValid = crypto.timingSafeEqual(compareBuffer, expected);
+  isValid = isValid && isValidLength;
+
+  if (!isValid) {
     throw new Error('HMAC verification failed');
   }
 }

--- a/functions/ticketing.js
+++ b/functions/ticketing.js
@@ -391,10 +391,13 @@ exports.verifyScanToken = onCall(
           .update(`${ticketId}:${piId}`)
           .digest('base64url');
 
-      const tokenMatch = crypto.timingSafeEqual(
-          Buffer.from(qrToken),
-          Buffer.from(expectedHmac),
-      );
+      const providedBuffer = Buffer.from(qrToken);
+      const expectedBuffer = Buffer.from(expectedHmac);
+      const isValidLength = providedBuffer.length === expectedBuffer.length;
+      const compareBuffer = isValidLength ? providedBuffer : expectedBuffer;
+      let tokenMatch = crypto.timingSafeEqual(compareBuffer, expectedBuffer);
+      tokenMatch = tokenMatch && isValidLength;
+
       if (!tokenMatch) {
         return {valid: false, status: 'invalid'};
       }

--- a/functions/tremendous.js
+++ b/functions/tremendous.js
@@ -224,10 +224,15 @@ function verifyWebhookSignature(rawBody, signature, secret) {
 
   const received = sigParts.v1 || signature;
 
-  if (!crypto.timingSafeEqual(
-      Buffer.from(expected, 'hex'),
-      Buffer.from(received.padEnd(expected.length, '0').slice(0, expected.length), 'hex'),
-  )) {
+  const expectedBuffer = Buffer.from(expected, 'hex');
+  const receivedBuffer = Buffer.from(received.padEnd(expected.length, '0').slice(0, expected.length), 'hex');
+
+  const isValidLength = expectedBuffer.length === receivedBuffer.length;
+  const compareBuffer = isValidLength ? receivedBuffer : expectedBuffer;
+  let isValid = crypto.timingSafeEqual(compareBuffer, expectedBuffer);
+  isValid = isValid && isValidLength;
+
+  if (!isValid) {
     throw new Error('Tremendous webhook signature mismatch');
   }
 }


### PR DESCRIPTION
🎯 **What:** The `crypto.timingSafeEqual` function requires buffers of identical length. If buffers of varying lengths are passed, it throws a `TypeError`. Checking the length before calling `timingSafeEqual` with an early return (or letting it throw) leaks the expected length of the payload/signature via timing side channels.

⚠️ **Risk:** An attacker could exploit this timing difference to guess the exact length of the expected signature or token, which is often a critical prerequisite step for orchestrating further cryptographic attacks or bypassing authentication layers entirely.

🛡️ **Solution:** Implemented the constant-time buffer selection pattern across all vulnerable instances in the codebase (`webhooksOps.js`, `facilityWeatherWebhook.js`, `magicUplinks.js`, `compliance.js`, `ticketing.js`, `apiGateway.js`, `tremendous.js`). If lengths mismatch, a dummy buffer (the expected buffer) is compared against the expected buffer, ensuring the execution time remains constant regardless of the attacker's input length. The result is only marked valid if both the lengths matched originally *and* the `timingSafeEqual` passed.

---
*PR created automatically by Jules for task [16973744379223196951](https://jules.google.com/task/16973744379223196951) started by @blueneekone*