### PR TITLE
🧪 [testing improvement] Add unit tests for stateForClub

### DIFF
--- a/src/lib/admin/__tests__/organizationsFilters.test.ts
+++ b/src/lib/admin/__tests__/organizationsFilters.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
 	filterClubsBySport,
 	filterOrganizations,
+	stateForClub,
 	tierForClub,
 	toggleInList,
 	verificationForClub,
@@ -29,6 +30,35 @@ describe('organizationsFilters', () => {
 	it('verificationForClub requires address and phone', () => {
 		expect(verificationForClub(SAMPLE[0]!)).toBe('verified');
 		expect(verificationForClub(SAMPLE[1]!)).toBe('pending');
+	});
+
+	describe('stateForClub', () => {
+		it('extracts state from standard 5-digit zip address', () => {
+			expect(stateForClub({ ...SAMPLE[0]!, verifiedAddress: '123 Main, Austin, TX 78701' })).toBe('TX');
+		});
+
+		it('extracts state from 9-digit zip address', () => {
+			expect(stateForClub({ ...SAMPLE[0]!, verifiedAddress: '123 Main, Austin, TX 78701-1234' })).toBe('TX');
+		});
+
+		it('returns empty string if address is empty', () => {
+			expect(stateForClub({ ...SAMPLE[0]!, verifiedAddress: '' })).toBe('');
+		});
+
+		it('returns empty string if address is undefined', () => {
+			expect(stateForClub({ ...SAMPLE[0]!, verifiedAddress: undefined })).toBe('');
+		});
+
+		it('returns empty string if address regex does not match', () => {
+			// Missing zip code
+			expect(stateForClub({ ...SAMPLE[0]!, verifiedAddress: '123 Main, Austin, TX' })).toBe('');
+			// Lowercase state (regex strictly requires uppercase A-Z)
+			expect(stateForClub({ ...SAMPLE[0]!, verifiedAddress: '123 Main, Austin, tx 78701' })).toBe('');
+			// Malformed zip code
+			expect(stateForClub({ ...SAMPLE[0]!, verifiedAddress: '123 Main, Austin, TX 7870' })).toBe('');
+			// Only state and zip code string
+			expect(stateForClub({ ...SAMPLE[0]!, verifiedAddress: 'NY 10001' })).toBe('NY');
+		});
 	});
 
 	it('tierForClub normalizes subscriptionTier', () => {


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was missing test coverage for `stateForClub` function which heavily relies on string matching and splitting that is susceptible to edge case bugs.
📊 **Coverage:** The new test cases cover standard 5-digit zip codes, 9-digit zip codes, empty strings, undefined inputs, and missing/malformed zip codes where the regex shouldn't match.
✨ **Result:** Test coverage for `src/lib/admin/organizationsFilters.ts` is improved and we now have verification protecting the logic that parses zipcodes into state acronyms.

---
*PR created automatically by Jules for task [1280439641752040747](https://jules.google.com/task/1280439641752040747) started by @blueneekone*