### PR TITLE
🧪 [testing improvement] Add tests for filterStateOptions

### DIFF
--- a/src/lib/admin/__tests__/organizationsFilters.test.ts
+++ b/src/lib/admin/__tests__/organizationsFilters.test.ts
@@ -5,6 +5,7 @@ import {
 	tierForClub,
 	toggleInList,
 	verificationForClub,
+	filterStateOptions,
 } from '$lib/admin/organizationsFilters.js';
 import type { AdminClub } from '$lib/types/adminOrganizations.js';
 
@@ -71,6 +72,36 @@ describe('organizationsFilters', () => {
 		it('returns empty array if no clubs match the sport', () => {
 			const filtered = filterClubsBySport(SAMPLE, 'football' as any);
 			expect(filtered).toHaveLength(0);
+		});
+	});
+
+	describe('filterStateOptions', () => {
+		const states = ['TX', 'CA', 'NY', 'FL', 'WA'];
+
+		it('returns all states when query is empty', () => {
+			expect(filterStateOptions(states, '')).toEqual(states);
+		});
+
+		it('returns all states when query is just whitespace', () => {
+			expect(filterStateOptions(states, '   ')).toEqual(states);
+		});
+
+		it('filters states case-insensitively', () => {
+			expect(filterStateOptions(states, 'tx')).toEqual(['TX']);
+			expect(filterStateOptions(states, 'tX')).toEqual(['TX']);
+			expect(filterStateOptions(states, 'Tx')).toEqual(['TX']);
+		});
+
+		it('filters states based on partial matches', () => {
+			expect(filterStateOptions(['NEW YORK', 'NEW JERSEY', 'CALIFORNIA'], 'NEW')).toEqual(['NEW YORK', 'NEW JERSEY']);
+		});
+
+		it('returns an empty array when no states match', () => {
+			expect(filterStateOptions(states, 'ZZ')).toEqual([]);
+		});
+
+		it('trims whitespace from the query', () => {
+			expect(filterStateOptions(states, '  CA  ')).toEqual(['CA']);
 		});
 	});
 });


### PR DESCRIPTION
🎯 **What:** Added tests for the `filterStateOptions` function in `src/lib/admin/organizationsFilters.ts`.
📊 **Coverage:** The tests cover scenarios including empty queries, whitespace, case insensitivity, partial matches, and negative matches.
✨ **Result:** Enhanced test coverage and reliability for organization filtering logic.

---
*PR created automatically by Jules for task [359742228137439269](https://jules.google.com/task/359742228137439269) started by @blueneekone*