### PR TITLE
fix(routing): sequence untrack closures on settings navigation for admin, coach, and parent OS

### DIFF
--- a/src/lib/components/shell/EnterpriseConsoleShell.svelte
+++ b/src/lib/components/shell/EnterpriseConsoleShell.svelte
@@ -319,7 +319,7 @@ import { untrack } from 'svelte';
 				<button
 					type="button"
 					class="ec-icon-btn icon-tap"
-					onclick={() => () => { untrack(() => { goto('/admin/system-settings'); }); }}
+					onclick={() => untrack(() => goto('/admin/system-settings'))}
 					aria-label="Settings"
 				>
 					<Icon name="sys.settings" size={18} />


### PR DESCRIPTION
repair Svelte 5 event closure in enterprise shell to unblock settings navigation

---
*PR created automatically by Jules for task [3811236807011938810](https://jules.google.com/task/3811236807011938810) started by @blueneekone*