### PR TITLE
🧹 [code health] Remove debug console.log from tacticalWarRoom

### DIFF
--- a/src/lib/states/war-room/tacticalWarRoom.svelte.ts
+++ b/src/lib/states/war-room/tacticalWarRoom.svelte.ts
@@ -624,7 +624,6 @@ export function createTacticalWarRoom(host: TacticalGridHost) {
 	}
 
 	function deleteRoute(routeId: string) {
-		console.log('[DEBUG] gridEngine.deleteRoute called with', routeId);
 		api.deleteRoute(host, routeId, () => selectedRouteId, (v) => (selectedRouteId = v));
 		routeContextMenuOpen = false;
 	}


### PR DESCRIPTION
🎯 **What:** Removed a leftover debug `console.log` statement from `deleteRoute` in `src/lib/states/war-room/tacticalWarRoom.svelte.ts`.
💡 **Why:** To improve code health, maintainability, and clean up the production console output by removing unnecessary debug statements.
✅ **Verification:** Verified the fix by running format/lint checks (`npm run check`) and the full test suite (`npm run test`), ensuring no regressions were introduced.
✨ **Result:** Cleaner codebase and cleaner console output without affecting any business logic.

---
*PR created automatically by Jules for task [2916571666801752260](https://jules.google.com/task/2916571666801752260) started by @blueneekone*