### PR TITLE
fix(script): improve regex for import filtering in cleanup script

### DIFF
--- a/workspace_cleanup_and_heal-v2.py
+++ b/workspace_cleanup_and_heal-v2.py
@@ -150,17 +150,25 @@ def heal_local_codebase():
                             continue
 
                         if re.match(r"^\s*import\b", line):
-                            if ";" not in stripped and "from" not in stripped:
+                            if ";" not in stripped and not re.search(r"\bfrom\b", stripped):
                                 in_import = True
                             continue
                         if in_import:
-                            if ";" in stripped or "from" in stripped:
+                            if ";" in stripped or re.search(r"\bfrom\b", stripped):
                                 in_import = False
                             continue
 
                         if stripped.startswith("//") or stripped.startswith("*") or stripped.startswith("/*"):
                             continue
-                        if "import" in line or "export" in line or "from" in line:
+
+                        # Skip inline single-line import/export statements explicitly containing "onIdTokenChanged"
+                        if re.match(r"^\s*(import|export)\b.*onIdTokenChanged", line):
+                            continue
+
+                        # Skip function definitions or assignments
+                        if re.search(r"\bfunction\s+onIdTokenChanged\s*\(", line):
+                            continue
+                        if re.search(r"^\s*(const|let|var)\s+onIdTokenChanged\s*=\s*", line):
                             continue
 
                         # ONLY match if it is an actual function listener / call site in an active execution block


### PR DESCRIPTION
This PR improves the auto-healer script parsing logic for `workspace_cleanup_and_heal-v2.py` where it previously mis-identified some single-line `import`, `export`, or `from` uses as execution blocks. Using `re.search` over the entire text was too aggressive. Now it explicitly checks boundaries and skips function definitions.

---
*PR created automatically by Jules for task [1424976833118719066](https://jules.google.com/task/1424976833118719066) started by @blueneekone*